### PR TITLE
Appendix E Tidying

### DIFF
--- a/doc/appendix/E/README.md
+++ b/doc/appendix/E/README.md
@@ -15,9 +15,3 @@ For centrally defined artifact types, there might be special support in the
 standard OCM library and tool set. For example, there is a dedicated downloader
 for helm charts providing the filesystem helm chart format regardless of
 the storage method and supported media type.
-
-Besides these centrally defined types, some typically used vendor specific types are:
-
-- [`landscaper.gardener.cloud/blueprint`](blueprint.md) an installation description for the landscaper tool
-- [`toiPackage`](toiPackage.md) a package for the Tiny OCM Installation Framework.
-- [`toiExecutor`](toiExecutor.md) an executor for the Tiny OCM Installation Framework


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does some small cleanup on the formatting and language of appendix E, specifically:
- format artifact types as table
- tidy spelling and improve readability
- remove vendor specific types from the spec (support for these is outlined elsewhere, not relevant here)

**Which issue(s) this PR fixes**:
Closes #3

**Special notes for your reviewer**:
