### PR TITLE
Link Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+Welcome to the OCM community!
+
+We welcome many different types of contributions.
+
+Please refer to the [Contributing Guide in the Community repository](https://github.com/open-component-model/community/blob/main/CONTRIBUTING.md) for more information on how to get support from maintainers, find work to contribute, the Pull Request checklist, the Pull Request process, and other useful information on contributing to the OCM projects.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ transporting and signing of component versions.
 
 ## Contributing
 
-Code contributions, feature requests, bug reports, and help requests are very welcome.
+Code contributions, feature requests, bug reports, and help requests are very welcome. Please refer to the [Contributing Guide in the Community repository](https://github.com/open-component-model/community/blob/main/CONTRIBUTING.md) for more information on how to contribute to OCM.
 
 OCM follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a link to the Contributing Guide in the `community` repo to be found from the `ocm-spec` repo.