### PR TITLE
replace gardener with open-component-model in various places

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119]
 
 ## Model Support
 
-Accompanying to this specification a ready-to-go [reference implementation](https://github.com/gardener/ocm)
+Accompanying to this specification a ready-to-go [reference implementation](https://github.com/open-component-model/ocm)
 is provided, which supports the common environment and access types for objects
 in the Kubernetes ecosystem. A (Go) library provides a framework for
 adding further implementations of the [model extension points](doc/appendix/README.md) under the hood
-of a generic OCM API, and a [command line tool](https://github.com/gardener/ocm/blob/main/docs/reference/ocm.md)
+of a generic OCM API, and a [command line tool](https://github.com/open-component-model/ocm/blob/main/docs/reference/ocm.md)
 based on this library supports general operations, like composing, viewing,
 transporting and signing of component versions.
 

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ To use a backend storage technology as an OCM repository it is necessary to prov
 
 2 [OCM Specification](doc/specification/README.md)
 
-2.1 [OCM Elements](doc/specification/layer1/README.md) <br>
+2.1 [OCM Elements](doc/specification/elements/README.md) <br>
 2.2 [OCM Operations](doc/specification/operations/README.md) <br>
 2.3 [Storage Backend Mappings](doc/specification/mapping/README.md) <br>
 2.4 [Formats and Names](doc/specification/formats/README.md) <br>
-2.5 [Denotation Schemes](doc/specification/fdenotations/README.md) <br>
+2.5 [Denotation Schemes](doc/specification/denotations/README.md) <br>
 
 3 [Scenarios](doc/scenarios/README.md) <br>
 

--- a/doc/appendix/A/OCIRegistry/README.md
+++ b/doc/appendix/A/OCIRegistry/README.md
@@ -63,7 +63,7 @@ An OCM *version name* of a component version is mapped to an OCI *tag*.
 
 The *component version* is represented as OCI *image manifest*.
 
-This manifest uses a config media type `application/vnd.gardener.cloud.cnudie.component.config.v1+json`.
+This manifest uses a config media type `application/vnd.ocm.software.component.config.v1+json`.
 According to the [OCI image specification](https://github.com/opencontainers/image-spec/blob/main/spec.md) this must be a JSON blob.
 This json file has one defined formal field:
 
@@ -71,7 +71,7 @@ This json file has one defined formal field:
 
   It references the layer blob containing the component descriptor. The layer
   always must be layer 0 of the manifest. It uses the media type
-  `application/vnd.gardener.cloud.cnudie.component-descriptor.v2+yaml+tar`
+  `application/vnd.ocm.software.component-descriptor.v2+yaml+tar`
 
 
 TODO: decide which media type to use for v3 descriptors.

--- a/doc/appendix/A/OCIRegistry/README.md
+++ b/doc/appendix/A/OCIRegistry/README.md
@@ -74,8 +74,6 @@ This json file has one defined formal field:
   `application/vnd.ocm.software.component-descriptor.v2+yaml+tar`
 
 
-TODO: decide which media type to use for v3 descriptors.
-
 The descriptor layer contains a tar archive with at least a single file
 with the name `component-descriptor.yaml` containing the component descriptor of the
 component version. This file should always be the first file in the tar archive.

--- a/doc/appendix/E/toiExecutor.md
+++ b/doc/appendix/E/toiExecutor.md
@@ -1,12 +1,12 @@
 # `toiExecutor` &#8212; Tiny OCM Installer
 
-TOI is a small toolset on top of the [Open Component Model](../../../README.md). 
+TOI is a small toolset on top of the [Open Component Model](../../../README.md).
 It provides
 a possibility to run images taken from a component version with user
 configuration and feed them with the content of this component version.
 It is some basic mechanism which can be used to execute simple installation
 steps based on content described by the Open Component Model
-(see https://github.com/gardener/ocm/docs/reference/ocm_toi-bootstrapping.md).
+(see https://github.com/open-component-model/ocm/blob/main/docs/reference/ocm_toi-bootstrapping.md).
 
 A TOI executor is YAML resource describing the features of an
 TOI executor image.

--- a/doc/appendix/E/toiPackage.md
+++ b/doc/appendix/E/toiPackage.md
@@ -6,8 +6,8 @@ a possibility to run images taken from a component version with user
 configuration and feed them with the content of this component version.
 It is some basic mechanism which can be used to execute simple installation
 steps based on content described by the Open Component Model
-(see https://github.com/gardener/ocm/docs/reference/ocm_toi-bootstrapping.md).
+(see https://github.com/open-component-model/ocm/blob/main/docs/reference/ocm_toi-bootstrapping.md).
 
 A TOI package is YAML resource describing the installation handling
-for a dedicated software package based on one or more 
+for a dedicated software package based on one or more
 [`toiExecutor`](toiExecutor.md)s.

--- a/doc/appendix/common/formatspec.md
+++ b/doc/appendix/common/formatspec.md
@@ -1,7 +1,7 @@
 
 # *Common Transport Format*
 
-The *Common Transport Format* describes a file system structure that can be 
+The *Common Transport Format* describes a file system structure that can be
 used for the representation of [content](https://github.com/opencontainers/image-spec)
 of an OCI repository.
 
@@ -29,7 +29,7 @@ It is a directory containing
   The artefact index describes the OCI manifests (image manifests and index
   manifests), which refer to further non-manifest blobs.
   Files not referenced by the artefacts described by the index are ignored.
-  
+
 
 This format might be used in various technical forms: as structure of an
 operating system file system, a virtual file system or as content of
@@ -38,7 +38,7 @@ an archive file. The descriptor SHOULD be the first file if stored in an archive
 ## *Artefact Index*
 
 The *Artefact Index* is a JSON file describing the artefact content in
-a file system structure according to this specification. 
+a file system structure according to this specification.
 
 ### *Artefact Index* Property Descriptions
 
@@ -48,7 +48,7 @@ It contains the following properties.
 
   This REQUIRED property specifies the index schema version.
   For this version of the specification, this MUST be `1`. The value of this
-  field will not change. This field MAY be removed in a future version of the 
+  field will not change. This field MAY be removed in a future version of the
   specification.
 
 - **`index`** *[artefact](#artefact-property-descriptions)*
@@ -76,13 +76,13 @@ The following fields contain the properties that constitute an *Artefact*:
 
 - **`tag`** *string*
 
-  This optional property is the _tag_ of the targeted artefact, conforming to 
+  This optional property is the _tag_ of the targeted artefact, conforming to
   the requirements outlined in the
   [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md).
 
   There might be multiple entries in the artefact list referring to the same artefact
   with different tags. But all used tags for a repository must be unique.
-  
+
 
 ## *Artefact Set Archive* Format
 
@@ -107,7 +107,7 @@ The file structure is a directory containing
 
   The *blobs* directory contains the blobs described by the artefact set descriptor
   as a flat file list. Every file has a filename according to its
-  [digest](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests). 
+  [digest](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests).
   Hereby the algorithm separator character is replaced by a dot (".").
   Every file SHOULD be referenced in the artefact descriptor by a
   [descriptor according the OCI Image Specification](https://github.com/opencontainers/image-spec/blob/main/descriptor.md).
@@ -127,22 +127,22 @@ Additionally this specification describes two special annotations, that can be
 set for any described artefact in the annotations attribute of the manifest
 list entries:
 
-- **`cloud.gardener.ocm/tags`**
-  
+- **`software.ocm/tags`**
+
   This annotation can be used to describe a comma-separated list of tags.
   that should be added for this index entry, when imported into an OCI registry.
 
-- **`cloud.gardener.ocm/type`**
+- **`software.ocm/type`**
 
   This annotation can be used for some additional type information.
 
 For the annotations of the index itself the following keys are defined:
 
-- **`cloud.gardener.ocm/main`** *digest*
+- **`software.ocm/main`** *digest*
 
   This annotation describes the digest of the main artefact of the set, if used
   as blob format for an artefact
-  
+
 This way the format can be used to attach elements according to various extension
 models for the OCI specification:
 
@@ -157,9 +157,9 @@ models for the OCI specification:
 
  - [*ORAS*](https://github.com/oras-project/artifacts-spec)
 
-   Here a new third top-level manifest type is introduced, that can be 
+   Here a new third top-level manifest type is introduced, that can be
    stored via the manifest endpoint of the distribution spec. No additional
    tags are required, the relation to the annotated object is established
-   by a dedicated digest based field. Those artefacts can directly be 
+   by a dedicated digest based field. Those artefacts can directly be
    described by this format. But language bindings basically have to support
    this additional type.

--- a/doc/introduction/README.md
+++ b/doc/introduction/README.md
@@ -53,9 +53,6 @@ predict the future, apart from the fact that things will always change, especial
 adapt to future trends, without constantly affecting the processes and tools responsible for the core of the lifecycle
 management of software, is a must.
 
-**Todo: Describe why existing component models could not be used, why is our model better**
-**Todo: Add image**
-
 ## Scope
 
 Operating software installations/products, both for cloud and on-premises, covers many aspects:

--- a/doc/introduction/README.md
+++ b/doc/introduction/README.md
@@ -173,12 +173,12 @@ component:
     access:            # -> access information how to locate this resource
       globalAccess:
         digest: sha256:57563cb451bb79eb1c4bf0e71c66fdad1daf44fe55e128f12eae5f7e5496a188
-        mediaType: application/vnd.toi.gardener.cloud.package.v1+yaml
+        mediaType: application/vnd.toi.ocm.software.package.v1+yaml
         ref: ghcr.io/jensh007/ctf/component-descriptors/github.com/open-component-model/ocmechoserver
         size: 615
         type: ociBlob
       localReference: sha256:57563cb451bb79eb1c4bf0e71c66fdad1daf44fe55e128f12eae5f7e5496a188
-      mediaType: application/vnd.toi.gardener.cloud.package.v1+yaml
+      mediaType: application/vnd.toi.ocm.software.package.v1+yaml
       type: localBlob
     labels:            # -> labels on this resource as key-value pairs
     - name: commit

--- a/doc/proposal/02-component-descriptor.md
+++ b/doc/proposal/02-component-descriptor.md
@@ -95,7 +95,7 @@ The *component* field of a *Component Descriptor* has the following fields:
 
 ### Component Name and Version
 
-Every *Component Descriptor* has a name and version, also called component name and component version. Name and version 
+Every *Component Descriptor* has a name and version, also called component name and component version. Name and version
 are the identifier for a *Component Descriptor* and the component version described by it.
 
 ```
@@ -107,7 +107,7 @@ component:
 ```
 
 Component names reside in a global namespace. To avoid name conflicts component names MUST start with a valid domain
-name (as specified by [RFC-1034](https://www.rfc-editor.org/info/rfc1034), [RFC-1035](https://www.rfc-editor.org/info/rfc1035)) 
+name (as specified by [RFC-1034](https://www.rfc-editor.org/info/rfc1034), [RFC-1035](https://www.rfc-editor.org/info/rfc1035))
 followed by an optional URL path suffix (as specified by [RFC-1738](https://www.rfc-editor.org/info/rfc1738)).
 
 Examples are:
@@ -115,12 +115,12 @@ Examples are:
 - *github.com*
 - *github.com/pathToYourRepo*
 
-If no URL path suffix is specified, the domain MUST be possessed by the component owner. If a URL path suffix is 
-specified, the namespace started by the concatenation of domain and URL path suffix MUST be controlled by the 
+If no URL path suffix is specified, the domain MUST be possessed by the component owner. If a URL path suffix is
+specified, the namespace started by the concatenation of domain and URL path suffix MUST be controlled by the
 component owner.
 
-A component name SHOULD reference a location where the component’s resources (typically source 
-code, and/or documentation) are hosted. An example and recommended practise is using GitHub repository names for 
+A component name SHOULD reference a location where the component’s resources (typically source
+code, and/or documentation) are hosted. An example and recommended practise is using GitHub repository names for
 components on GitHub like *github.com/path-of-your-repo*.
 
 Component versions refer to specific snapshots of a component. A common scenario being the release of a component.
@@ -171,7 +171,7 @@ component:
     access:
       commit: e01326928b6f9825dba9fa530b8d4917f93194b0
       ref: refs/tags/v1.19.4
-      repoUrl: github.com/gardener/example-sources-1
+      repoUrl: github.com/my.org/example-sources-1
       type: github
       ...
 ```
@@ -211,7 +211,7 @@ Sources and resources declare through their access attribute a means to access t
 This is done by declaring an access type (for example an OCI Image Registry), which defines the protocol through which
 access is done. Depending on the access type, additional attributes are required (e.g. an OCI Image Reference).
 
-OCM specifies the format and semantics of particular access types for particular resources and sources later in this 
+OCM specifies the format and semantics of particular access types for particular resources and sources later in this
 specification.
 
 ### References to Components
@@ -236,10 +236,10 @@ component:
     version: v1.38.3
   - name: name-2
     componentName: .../component-name-2
-    version: v0.11.4 
+    version: v0.11.4
 ```
 
-As elaborated later in the context of *Component Repositories*, references to components do not need to declare an 
+As elaborated later in the context of *Component Repositories*, references to components do not need to declare an
 access attribute. The lookup is always done by their name and version.
 
 ### Identifier for Sources, Resources and Component References
@@ -256,7 +256,7 @@ for valid names are defined:
 Every *source*, *resource* or *componentReference* needs a unique identifier in a *Component Descriptor*.
 In particular situations the name and version are not sufficient, e.g. if docker images for different platform are included.
 Therefore, every entry has an additional optional field *extraIdentity* to resolve this problem, i.e. every entry
-MUST have a unique combination of *name*, *version*, *extraIdentity* and formal type (*source*, *resource* or 
+MUST have a unique combination of *name*, *version*, *extraIdentity* and formal type (*source*, *resource* or
 *componentReference*) within a *Component Descriptor*.
 
 An *extraIdentity* is a map, of key value pairs whereby:
@@ -287,9 +287,9 @@ component:
 
 ### Labels
 
-According to the [schema](component-descriptor-v2-schema.yaml) for the *Component Descriptor*, additional fields are 
-not allowed. This express application specific extensions, every entry in the *sources*, *resources* and 
-*componentReferences* fields, and the component itself may declare optional labels. 
+According to the [schema](component-descriptor-v2-schema.yaml) for the *Component Descriptor*, additional fields are
+not allowed. This express application specific extensions, every entry in the *sources*, *resources* and
+*componentReferences* fields, and the component itself may declare optional labels.
 
 Labels is a map, of key value pairs whereby:
 
@@ -308,15 +308,15 @@ component:
 
 ### Repository Contexts
 
-Every *Component Descriptor* has a field *repositoryContexts* containing an array of access information of 
-*Component Descriptor Repositories*, i.e. stores for *Component Descriptors* which are specified later. 
+Every *Component Descriptor* has a field *repositoryContexts* containing an array of access information of
+*Component Descriptor Repositories*, i.e. stores for *Component Descriptors* which are specified later.
 
 The array of access information describes the transport chain of a *Component Descriptor* through different
 *Component Descriptor Repositories*, whereby the last entry describes the current *Component Descriptor Repository*,
 in which the *Component Descriptor* is stored.
 
-The *repositoryContexts* are usually not specified manually in the *Component Descriptor*, but are rather set 
-automatically when a component version is uploaded to a *Component Repository*. 
+The *repositoryContexts* are usually not specified manually in the *Component Descriptor*, but are rather set
+automatically when a component version is uploaded to a *Component Repository*.
 
 
 

--- a/doc/proposal/04-local-blobs.md
+++ b/doc/proposal/04-local-blobs.md
@@ -7,7 +7,7 @@ access path. For the component model those resources are just seen as simple typ
 This enables to formally reference blobs in external environments, as long as the described method is
 known to the consuming environment. The evaluation of an access specification always results in a simple blob
 representing the content of the described resource. This way basically all required blobs can be stored in any
-supported external blob store. 
+supported external blob store.
 
 When using the component repository to transport content from one repository the another one
 (possibly behind a firewall without access to external blob repositories), the described content of a component
@@ -28,23 +28,23 @@ blobs under the identity of the component descriptor. A repository implementatio
 to a predefinied other blob store or handle this part of the API in its own way.
 
 This enables:
-- a simple usage of a component repository to store any content without the need of always requiring other 
-  externals stores for (possibly specific types of) resources. (for example for storing sinmple configuration data 
+- a simple usage of a component repository to store any content without the need of always requiring other
+  externals stores for (possibly specific types of) resources. (for example for storing sinmple configuration data
   along with the component descriptor)
 - providing a respository implementation for filesystem formats that can transparently be used by component tools.
 - the usage of a minimal repository environment on the target side of a transport by just using a dedicated
   component repository.
 
-Therefore, *Component Repositories* MUST provide the possibility to store technical artifacts together with the 
+Therefore, *Component Repositories* MUST provide the possibility to store technical artifacts together with the
 *Component Descriptors* in the *Component Repository* itself as so-called *local blobs*. Therefore a dedicated general
-access type `localBlob` is used that MUST be implemented by all repository implementations. This also allows to pack all 
-component versions with their technical artifacts in a *Component Repository* as a completely self-contained package, a 
-typical requirement if you need to deliver your product into a fenced landscape. 
+access type `localBlob` is used that MUST be implemented by all repository implementations. This also allows to pack all
+component versions with their technical artifacts in a *Component Repository* as a completely self-contained package, a
+typical requirement if you need to deliver your product into a fenced landscape.
 
-As a short example, assume some component needs additional configuration data stored in some YAML file. If 
-in some landscape of your transport chain there is only an OCI registry available to store content, then you need to 
+As a short example, assume some component needs additional configuration data stored in some YAML file. If
+in some landscape of your transport chain there is only an OCI registry available to store content, then you need to
 define a format how to store such a YAML file in the OCI registry. With *local blobs* you could just upload the file into
-the *Component Repository*. 
+the *Component Repository*.
 
 ## Functions for Local Blobs
 
@@ -95,7 +95,7 @@ the resource, e.g. if the blob contains the data of an OCI image it could provid
 
 **Example**:
 Assume you want to upload an OCI image to your *Component Repository* with the *UploadLocalBlob* function with media type
-*application/vnd.oci.image.manifest.v1+tar+gzip*. The reference information can be set to the originial image name *gardener/specialimage*
+*application/vnd.oci.image.manifest.v1+tar+gzip*. The reference information can be set to the originial image name *my-org/specialimage*
 to give a target repository a hint for determining the identity of a potential global access:
 
 ```
@@ -106,15 +106,15 @@ The request to store the local blob the looks as follows:
 
 ```
   mediaType: application/vnd.oci.image.manifest.v1+tar+gzip
-  referenceName: gardener/specialimage
+  referenceName: my-org/specialimage
   localReference: "sha256:b5733194756a0a4a99a4b71c4328f1ccf01f866b5c3efcb4a025f02201ccf623"
-... 
+...
 ```
 
 The *Component Repository* (in case it supports direct OCI access) could also provide some derived *globalAccessInfo* additionally containing the location in an OCI registry:
 
 ```
-imageReference: <repository prefix>/gardener/specialimage@sha:...
+imageReference: <repository prefix>/my-org/specialimage@sha:...
 type: ociRegistry
 ```
 
@@ -128,12 +128,12 @@ An entry to this resource with this information in the *Component Descriptor* th
     access:
       type: localBlob
       mediaType: application/vnd.oci.image.manifest.v1+json
-      referenceName: gardener/specialimage
+      referenceName: my-org/specialimage
       localReference: "sha256:b5733194756a0a4a99a4b71c4328f1ccf01f866b5c3efcb4a025f02201ccf623"
-      globalAccess: 
-        imageReference: <repository prefix>/gardener/specialimage@sha:...
+      globalAccess:
+        imageReference: <repository prefix>/my-org/specialimage@sha:...
         type: ociRegistry
-... 
+...
 ```
 
 Optionally the repository could even omit the storage as local blob, and just provide a global type specific access specification
@@ -146,8 +146,8 @@ Optionally the repository could even omit the storage as local blob, and just pr
     type: oci-image
     access:
       type: ociRegistry
-      imageReference: <repository prefix>/gardener/specialimage@sha:...
-... 
+      imageReference: <repository prefix>/my-org/specialimage@sha:...
+...
 ```
 
 The repository implementation is free to decide on the storage of local blobs based on the input information, it just has to return the
@@ -182,7 +182,7 @@ access information you got when you uploaded the local blob.
 A *Component Repository* MAY implement a method for listing *local blobs* as specified in this chapter.
 
 **Description**: Provides an iterator over all triples *componentName/componentVersion/localAccessInfo* of all
-uploaded blobs. 
+uploaded blobs.
 
 **Inputs**:
 

--- a/doc/proposal/in-progress/05-component-repository-oci.md
+++ b/doc/proposal/in-progress/05-component-repository-oci.md
@@ -1,34 +1,34 @@
 # OCI Component Repository
 
-This chapter describes an implementation of a Component Repository which stores component descriptors in an OCI image 
+This chapter describes an implementation of a Component Repository which stores component descriptors in an OCI image
 registry. We call this implementation *OCI Component Repository*.
 
 An OCI component repository is defined by a *base URL*. This URL MUST refer to an OCI image registry or a path
-into it. Component descriptors can be stored here as OCI artifacts. The name of the artifact is derived from the 
+into it. Component descriptors can be stored here as OCI artifacts. The name of the artifact is derived from the
 base URL, the component name, and component version:
 
 ```text
 <base URL>/component-descriptors/<component name>:<component version>
 ```
 
-A component descriptor can reference resources of type `localBlob`. These resources are stored as blobs in the same 
-OCI artifact as the component descriptor. The artifact is the structured as follows. It consists of a manifest, 
-a config, and an array of layers. The component descriptor is the first layer, and the local OCI blobs are stored in the 
-other layers. 
+A component descriptor can reference resources of type `localBlob`. These resources are stored as blobs in the same
+OCI artifact as the component descriptor. The artifact is the structured as follows. It consists of a manifest,
+a config, and an array of layers. The component descriptor is the first layer, and the local OCI blobs are stored in the
+other layers.
 
 ![images/component-artifact.png](../images/component-artifact.png)
 
 The component descriptor and its local OCI blobs can be accessed via the OCI blobs endpoint of the repository.
 To get a layer via the OCI blobs endpoint one needs to know the digest of this layer.
 
-The digest of the component descriptor layer can be found in two ways. It is the first layer in the manifest. 
-In addition, the config of the artifact contains a reference to the component descriptor layer, as shown in the 
+The digest of the component descriptor layer can be found in two ways. It is the first layer in the manifest.
+In addition, the config of the artifact contains a reference to the component descriptor layer, as shown in the
 following example of a config.json:
 
 ```json
 {
     "componentDescriptorLayer": {
-        "mediaType": "application/vnd.gardener.cloud.cnudie.component-descriptor.v2+yaml+tar",
+        "mediaType": "application/vnd.ocm.software.component-descriptor.v2+yaml+tar",
         "digest": "sha256:6303ce21c1c8b5a9dfd9d6616cce976558d84542ac2eca342e3267f7205f2759",
         "size": 3584
     }

--- a/doc/proposal/leftovers.md
+++ b/doc/proposal/leftovers.md
@@ -3,26 +3,26 @@
 - Repository Context in CD
   - current schema only allows OCI-Ref, this needs to be extensible
   - Should OCI ref be part of this spec?
-    
+
 - Clarify: Components are not allowed to have two version with the same number but different formats, e.g. v0.1.0 and 0.1.0
 
 ## Topics to be added to the Specification
-  1. Particular types (which types are supported ?). Backlog Item: https://github.com/gardener/ocm-spec/issues/3
-  3. Transport (incl. CTF). Backlog Item: https://github.com/gardener/ocm-spec/issues/4
-  4. Signing (already in progress: https://github.com/gardener/ocm-spec/blob/main/doc/proposal/in-progress/07-signing.md). Backlog Item: https://github.com/gardener/ocm-spec/issues/5
+  1. Particular types (which types are supported ?). Backlog Item: https://github.com/open-component-model/ocm-spec/issues/3
+  3. Transport (incl. CTF). Backlog Item: https://github.com/open-component-model/ocm-spec/issues/4
+  4. Signing (already in progress: https://github.com/open-component-model/ocm-spec/blob/main/doc/proposal/in-progress/07-signing.md). Backlog Item: https://github.com/open-component-model/ocm-spec/issues/5
 
 ## Additional sections for the Specification
-- we need namespace structure for 
+- we need namespace structure for
   - logical types in references
   - access methods/types in references
   - label names
   - short names allowed for our definitions e.g. ociImage
-  
-  - Work on this topic started under https://github.com/gardener/ocm/blob/master/docs/names/README.md, linked from https://github.com/gardener/ocm. Should be moved to the ocm-spec repository and linked properly.
-  
-- Add a chapter with terminology (see https://github.com/openservicebrokerapi/servicebroker/blob/v2.16/spec.md#notations-and-terminology)  
-  - Terminology section: beside others must describe landscape, component version, snapshot: Backlog item: https://github.com/gardener/ocm-spec/issues/9
-- Add complete component descriptor example: Backlog item: https://github.com/gardener/ocm-spec/issues/8
+
+  - Work on this topic started under https://github.com/open-component-model/ocm/blob/master/docs/names/README.md, linked from https://github.com/open-component-model/ocm. Should be moved to the ocm-spec repository and linked properly.
+
+- Add a chapter with terminology (see https://github.com/openservicebrokerapi/servicebroker/blob/v2.16/spec.md#notations-and-terminology)
+  - Terminology section: beside others must describe landscape, component version, snapshot: Backlog item: https://github.com/open-component-model/ocm-spec/issues/9
+- Add complete component descriptor example: Backlog item: https://github.com/open-component-model/ocm-spec/issues/8
 - references in the text to the CD spec for particular entries
 - List with all errors and their semantics
 - Tables for presenting field descriptions (see https://github.com/openservicebrokerapi/servicebroker/blob/v2.16/spec.md)
@@ -31,4 +31,4 @@
 - Use-Cases / Scenarios with diagrams for Component Repos
 - example of local blobs with oci image not good
 - better motivation of flow für upload blobs (usually first blobs then component descriptor)
-- change technical artifacts to software artifacts 
+- change technical artifacts to software artifacts

--- a/doc/specification/elements/README.md
+++ b/doc/specification/elements/README.md
@@ -7,18 +7,25 @@ in some kind of repository.
 This leads to the following major elements that must be specified
 as part of the Open Component Model specification
 
-- [Repositories](#repositories)
-- [Components](#components)
-- [Component Versions](#component-versions)
+- [2.1 Model Structure and Elements](#21-model-structure-and-elements)
+  - [Repositories](#repositories)
+  - [Components](#components)
+  - [Component Versions](#component-versions)
+    - [Component Descriptor](#component-descriptor)
+    - [Composing the Artifact Set](#composing-the-artifact-set)
     - [Identities](#identities)
     - [Labels](#labels)
     - [Artifacts](#artifacts)
-        - [Sources](#sources)
-        - [Resources](#resources)
-        - [Artifact Access](#artifact-access)
+      - [Sources](#sources)
+      - [Resources](#resources)
+      - [Artifact Access](#artifact-access)
     - [Aggregation](#aggregation)
-- [Signatures](#signatures)
-- [Repository Contexts](#repository-contexts)
+    - [Artifact References](#artifact-references)
+      - [Absolute Artifact References](#absolute-artifact-references)
+  - [Signatures](#signatures)
+        - [Digest Info](#digest-info)
+        - [Signature Info](#signature-info)
+  - [Repository Contexts](#repository-contexts)
 
 Those elements partly use further sub-level elements that are
 defined in the context of their usage.
@@ -32,7 +39,7 @@ So far, we don't define a repository API for a dedicated technical native
 instance of an OCM repository, because we want to use existing storage
 subsystems, without the need of running OCM specific servers (Nevertheless,
 such an API is still compatible with this specification and could be defined in
-the future). 
+the future).
 
 Therefore, a component repository is typically an interpretation layer
 on-top of a given well-known storage
@@ -72,7 +79,7 @@ Hereby the DNS domain plus optionally any number of leading name components MUST
 be owned by the provider of a component. For example, `github.com`, as DNS domain
 is shared by lots of organizations. Therefore, all component identities provided
 based on this DNS name, must include the owner prefix of the providing
-organization, e.g. `github.com/gardener`.
+organization, e.g. `github.com/my-org`.
 
 The component acts as a namespace to host multiple [*Component Versions*](#component-versions),
 which finally describe dedicated technical artifact sets, which describe the
@@ -230,7 +237,7 @@ attributes. Selecting all artifacts for a dedicated purpose is possible
 by selecting all artifacts with the appropriate `name` attribute, without the
 need of parsing an artificial structure imprinted on the name attribute.
 
-<div align="center"> 
+<div align="center">
 <img src="ocmidentity.png" alt="Identities" width="800"/>
 </div>
 
@@ -389,7 +396,7 @@ global identity triple to the following procedure:
   and [resource](#resources))
 - [apply](../operations/README.md#access-method-operations) the described [access method](#artifact-access)
 
-<div align="center"> 
+<div align="center">
 <img src="ocmresourceaccess.png" alt="Structure of OCM Specification" width="800"/>
 </div>
 
@@ -431,10 +438,10 @@ artifact hosting the relative reference.
 
 CompVers: `A:1.0.0`
 ```
-- Resources: 
+- Resources:
   - name: DEPLOYER
   - type: mySpecialDeploymentDescription
-- 
+-
 - References:
   - name: content
     component: B:1.0.0
@@ -490,7 +497,7 @@ the pair by a third value, a component version identity.
 
 </div>
 
-In a dedicated interpretation environment such a location-agnostic reference can again be 
+In a dedicated interpretation environment such a location-agnostic reference can again be
 transferred into a location-specific reference by adding a [repository-context](#repository-contexts).
 
 Such a reference can then be used to finally address the content of this artifact by the

--- a/doc/specification/formats/compdesc/v2/json-schema.yaml
+++ b/doc/specification/formats/compdesc/v2/json-schema.yaml
@@ -1,6 +1,6 @@
-$id: 'https://gardener.cloud/schemas/component-descriptor-v2'
+$id: 'https://ocm.software/schemas/component-descriptor-v2'
 $schema: 'https://json-schema.org/draft/2020-12/schema'
-description: 'Gardener Component Descriptor v2 schema'
+description: 'Open Component Model v2 schema'
 definitions:
   meta:
     type: 'object'

--- a/doc/specification/formats/compdesc/v3alpha1/json-schema.yaml
+++ b/doc/specification/formats/compdesc/v3alpha1/json-schema.yaml
@@ -1,4 +1,4 @@
-$id: 'https://gardener.cloud/schemas/component-descriptor-ocm-v3alpha1'
+$id: 'https://ocm.software/schemas/component-descriptor-ocm-v3alpha1'
 $schema: 'https://json-schema.org/draft/2020-12/schema'
 description: 'OCM Component Descriptor v3 schema'
 definitions:
@@ -444,7 +444,7 @@ required:
 properties:
   apiVersion:
     type: 'string'
-    enum: [ 'ocm.gardener.cloud/v3alpha1' ]
+    enum: [ 'ocm.software/v3alpha1' ]
   kind:
     type: 'string'
     const: 'ComponentVersion'

--- a/example/upload-component-to-oci-registry.md
+++ b/example/upload-component-to-oci-registry.md
@@ -182,8 +182,8 @@ transferring version "github.com/yitsushi/hello-world:1.0.7"...
 INFO[0000] trying next host - response was http.StatusNotFound  host=ghcr.io
 INFO[0001] trying next host - response was http.StatusNotFound  host=ghcr.io
 ...adding component version...
-*** push application/vnd.gardener.cloud.cnudie.component-descriptor.v2+yaml+tar sha256:4e972b297e47151dacd2582b9acaf9a94cda0203fe148e81d4e5f59cd7b8710b: unknown-sha256:4e972b297e47151dacd2582b9acaf9a94cda0203fe148e81d4e5f59cd7b8710b
-*** push application/vnd.gardener.cloud.cnudie.component.config.v1+json sha256:2eae2829e60c287ac2dabd3daed4fed9a45a021ebe0c0ff29e9db20b160f3b53: unknown-sha256:2eae2829e60c287ac2dabd3daed4fed9a45a021ebe0c0ff29e9db20b160f3b53
+*** push application/vnd.ocm.software.component-descriptor.v2+yaml+ta sha256:4e972b297e47151dacd2582b9acaf9a94cda0203fe148e81d4e5f59cd7b8710b: unknown-sha256:4e972b297e47151dacd2582b9acaf9a94cda0203fe148e81d4e5f59cd7b8710b
+*** push application/vnd.ocm.software.component.config.v1+json sha256:2eae2829e60c287ac2dabd3daed4fed9a45a021ebe0c0ff29e9db20b160f3b53: unknown-sha256:2eae2829e60c287ac2dabd3daed4fed9a45a021ebe0c0ff29e9db20b160f3b53
 *** push application/vnd.oci.image.manifest.v1+json sha256:d3418290d87f05f52c1801557c00d3e43eb0bcf1bb960331b3967c639541582f: manifest-sha256:d3418290d87f05f52c1801557c00d3e43eb0bcf1bb960331b3967c639541582f
 pusher for ghcr.io/sap/component-descriptors/github.com/yitsushi/hello-world:1.0.7
 pushing 1.0.7


### PR DESCRIPTION
**What this PR does / why we need it**:
remove certain references to gardener in the spec and replace them by oc,

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
