### PR TITLE
refactor: use artifact instead of artefact everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@
 
 ## Overview
 
-The _Open Component Model (OCM)_ is an open standard to describe software-bill-of-deliveries (SBOD). OCM is a technology-agnostic and machine-readable format focused on the software artefacts that must be delivered for software products.
+The _Open Component Model (OCM)_ is an open standard to describe software-bill-of-deliveries (SBOD). OCM is a technology-agnostic and machine-readable format focused on the software artifacts that must be delivered for software products.
 
 By providing a globally unique identity scheme, OCM can be employed throughout the entire software lifecycle management process, from build to compliance, to deployment.
 
 It can be used as a common basis and lingua franca for the exchange, access and
-transport of delivery artefacts between different tools, processes and environments.
+transport of delivery artifacts between different tools, processes and environments.
 
-To support fenced or otherwise restricted environments, OCM provides a mechanism to transparently adapt access information for artefacts during transport. This means that applications accessing the component information in a particular environment always receive location specific access information that is valid for their own environment.
+To support fenced or otherwise restricted environments, OCM provides a mechanism to transparently adapt access information for artifacts during transport. This means that applications accessing the component information in a particular environment always receive location specific access information that is valid for their own environment.
 
-OCM is a technology-agnostic model to describe artefacts and the specific means by which to access their content. In this context we understand technology-agnostic to mean the following:
+OCM is a technology-agnostic model to describe artifacts and the specific means by which to access their content. In this context we understand technology-agnostic to mean the following:
 
-- the model can describe any artefact regardless of its technology
-- artefacts can be stored using any storage backend technology or repository
+- the model can describe any artifact regardless of its technology
+- artifacts can be stored using any storage backend technology or repository
 - the model information can be stored using any storage backend technology or repository
 
 ## Comparison with Software-Bill-of-Materials
 
 OCM is (explicitly) not meant to describe the complete bill of materials of a software product,
-in relation to the packages those delivery artefacts are composed of. This makes OCM a simpler model in comparison with standards such as [CycloneDX](https://cyclonedx.org/). OCM provides detailed and unambiguous specifications with respect to delivery and deployment related aspects such as transport and signing of software artefacts. Further information about artefacts (like typical SBOMs) can be added using labels, additional resources or even
+in relation to the packages those delivery artifacts are composed of. This makes OCM a simpler model in comparison with standards such as [CycloneDX](https://cyclonedx.org/). OCM provides detailed and unambiguous specifications with respect to delivery and deployment related aspects such as transport and signing of software artifacts. Further information about artifacts (like typical SBOMs) can be added using labels, additional resources or even
 component versions.
 
 ## Storage Technology
@@ -31,7 +31,7 @@ The Open Component Model is an interpretation layer on top of existing storage t
 
 To use a backend storage technology as an OCM repository it is necessary to provide:
 
-- an implementation for accessing artefacts in the desired backend and mapping them to a blob format
+- an implementation for accessing artifacts in the desired backend and mapping them to a blob format
 - a specification for a [mapping scheme](doc/specification/mapping/README.md)
   describing how to map the elements of the Open Component Model to the supported
   elements of the backend storage technology

--- a/doc/appendix/A/CTF/README.md
+++ b/doc/appendix/A/CTF/README.md
@@ -66,8 +66,8 @@ Local blobs are always stored as blobs.
 ## Examples
 
 ```text
-artefact-archive
-├── artefact-index.json
+artifact-archive
+├── artifact-index.json
 └── blobs
     ├── sha.123... (manifest.json)
     ├── sha.234... (config.json)
@@ -82,7 +82,7 @@ descriptor:
 ```json
 {
   "schemaVersion": 1,
-  "artefacts": [
+  "artifacts": [
     {
       "repository": "component-descriptors/<component name>>",
       "tag": "0.1.0",
@@ -93,28 +93,28 @@ descriptor:
 
 ```
 
-### Example of a transport archive containing two artefacts
+### Example of a transport archive containing two artifacts
 
 ```text
 transport-archive
-├── artefact-descriptor.json
+├── artifact-descriptor.json
 └── blobs
-    ├── sha256.111... (manifest.json of artefact 1)
-    ├── sha256.222... (config.json   of artefact 1)
-    ├── sha256.333... (layer         of artefact 1)
-    ├── sha256.444... (layer         of artefact 1)
-    ├── sha256.555... (manifest.json of artefact 2)
-    ├── sha256.666... (config.json   of artefact 2)
-    ├── sha256.777... (layer         of artefact 2)
-    └── sha256.888... (layer         of artefact 2)
+    ├── sha256.111... (manifest.json of artifact 1)
+    ├── sha256.222... (config.json   of artifact 1)
+    ├── sha256.333... (layer         of artifact 1)
+    ├── sha256.444... (layer         of artifact 1)
+    ├── sha256.555... (manifest.json of artifact 2)
+    ├── sha256.666... (config.json   of artifact 2)
+    ├── sha256.777... (layer         of artifact 2)
+    └── sha256.888... (layer         of artifact 2)
 ```
 
-The manifest list in the `artefact-descriptor.json` contains the tags for the two manifests:
+The manifest list in the `artifact-descriptor.json` contains the tags for the two manifests:
 
 ```json
 {
   "schemaVersion": 1,
-  "artefacts": [
+  "artifacts": [
     {
       "repository": "component-descriptors/<name of first component>",
       "tag": "0.1.0",

--- a/doc/appendix/A/OCIRegistry/README.md
+++ b/doc/appendix/A/OCIRegistry/README.md
@@ -19,7 +19,7 @@ type: ociRegistry/v1
 
 ### Description
 
-Artefact namespaces/repositories of the API layer will be mapped to an OCI
+Artifact namespaces/repositories of the API layer will be mapped to an OCI
 registry according to the [OCI distribution specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md).
 
 Supported specification version is `v1`.
@@ -91,8 +91,8 @@ access specification.
 
 ## Blob Mappings
 
-Local blobs with an OCI artefact media type will implicitly be mapped to a regular
-artefact. The *reference hint* provided by the specification of the local access
+Local blobs with an OCI artifact media type will implicitly be mapped to a regular
+artifact. The *reference hint* provided by the specification of the local access
 is used to compose a repository name of the form:
 
 <div align="center">
@@ -101,7 +101,7 @@ is used to compose a repository name of the form:
 
 </div>
 
-Without a given tag, the provided external access specification (of type `ociArtefact`)
+Without a given tag, the provided external access specification (of type `ociArtifact`)
 uses a digest based reference.
 
 Additional blob transformations can be added by registering appropriate blob handlers.

--- a/doc/appendix/A/README.md
+++ b/doc/appendix/A/README.md
@@ -20,7 +20,7 @@ Mappings for the following technologies are defined:
 - [FileSystem (CTF)](CTF/README.md) OCM content as filesystem structure
 - [AWS S3](S3/README.md)OCM content in AWS S3 buckets
 
-## Transport of Artefact Content
+## Transport of Artifact Content
 
 A [transport](../../introduction/transports.md) of a [component version](../../specification/elements/README.md#component-versions)
 from one [component repository](../../introduction/component_repository.md) into 
@@ -51,11 +51,11 @@ This enables:
   transport by just using a dedicated component repository.
 
 Therefore, *Component Repositories* MUST provide the possibility to store
-technical artefacts together with the component descriptors in the component
+technical artifacts together with the component descriptors in the component
 repository itself as so-called *local blobs*. Therefore, a dedicated general
 access type [`localBlob`](../B/localBlob.md)is used that MUST be implemented by all 
 repository implementations. This also allows to pack all component versions with their
-technical artefacts in a *Component Repository* as a completely self-contained
+technical artifacts in a *Component Repository* as a completely self-contained
 package, a typical requirement if you need to deliver your product into a fenced
 landscape.
 

--- a/doc/appendix/A/S3/README.md
+++ b/doc/appendix/A/S3/README.md
@@ -17,7 +17,7 @@ type: S3/v1
 
 ### Description
 
-Artefact namespaces/repositories of the API layer will be mapped to an 
+Artifact namespaces/repositories of the API layer will be mapped to an 
 S3 bucket.
 
 ### Specification Versions
@@ -42,7 +42,7 @@ by a namespace component `__versions__`.
 The OCM *component version* is stored below an additional folder with the
 version name of the component version.
 
-All artefacts belonging to a component version are stored as blobs below
+All artifacts belonging to a component version are stored as blobs below
 this folder.
 
 The OCM *component descriptor* of a component version is stored with the

--- a/doc/appendix/B/README.md
+++ b/doc/appendix/B/README.md
@@ -1,7 +1,7 @@
 # B.  Access Method Types
 
-[Access methods](../../specification/elements/README.md#artefact-access)
-are used to access the content of artefacts described
+[Access methods](../../specification/elements/README.md#artifact-access)
+are used to access the content of artifacts described
 by a [component version](../../specification/elements/README.md#component-versions).
 The [type](../../specification/formats/types.md#access-method-types)
 of the methods defines the access procedure and the
@@ -11,8 +11,8 @@ required to identity the blob and its location.
 
 The following access method types are centrally defined:
 
-- [localBlob](localBlob.md) an artefact stored along with the component version
-- [ociArtefact](ociArtefact.md) an artefact in a repository of an OCI registry
+- [localBlob](localBlob.md) an artifact stored along with the component version
+- [ociArtifact](ociArtifact.md) an artifact in a repository of an OCI registry
 - [ociBlob](ociBlob.md) a blob in a repository of an OCI registry
 - [gitHub](gitHub.md) a GitHub commit
 - [s3](s3.md) a blob stored in an AWS S3 bucket

--- a/doc/appendix/B/gitHub.md
+++ b/doc/appendix/B/gitHub.md
@@ -9,7 +9,7 @@ type: gitHub/v1
 
 Provided blobs use the following media type for: `application/x-tgz`
 
-The artefact content is provided as gnu-zipped tar archive
+The artifact content is provided as gnu-zipped tar archive
 
 ### Description
 

--- a/doc/appendix/B/localBlob.md
+++ b/doc/appendix/B/localBlob.md
@@ -45,12 +45,12 @@ The type specific specification fields are:
   other repositories to restore some global access with an identity
   related to the original source.
 
-  For example, if an OCI artefact originally referenced using the
-  access method [`ociArtefact`](../../../../../docs/formats/accessmethods/ociArtefact.md) is stored during
-  some transport step as local artefact, the reference name can be set
+  For example, if an OCI artifact originally referenced using the
+  access method [`ociArtifact`](../../../../../docs/formats/accessmethods/ociArtifact.md) is stored during
+  some transport step as local artifact, the reference name can be set
   to its original repository name. An import step into an OCI based OCM
-  repository may then decide to make this artefact available again as
-  regular OCI artefact.
+  repository may then decide to make this artifact available again as
+  regular OCI artifact.
 
 - **`globalAccess`** (optional) *access method specification*
 
@@ -58,8 +58,8 @@ The type specific specification fields are:
   may decide to provide an external access information (independent
   of the OCM model).
 
-  For example, an OCI artefact stored as local blob
-  can be additionally stored as regular OCI artefact in an OCI registry.
+  For example, an OCI artifact stored as local blob
+  can be additionally stored as regular OCI artifact in an OCI registry.
 
   This additional external access information can be added using
   a second external access method specification.
@@ -79,10 +79,10 @@ by registered blob handlers.
 #### Provided Blob Handlers
 
 The standard tool set uses the following registered blob handlers:
-- *Blob handler for importing oci artefact blobs into
+- *Blob handler for importing oci artifact blobs into
   an OCM repository mapped to an [OCI registry](../A/OCIRegistry/README.md#blob-mappings)*
 
-  In this case the oci artefact  blobs will be expanded to a regular
-  OCI artefact taking the optional `referenceName` into account.
+  In this case the oci artifact  blobs will be expanded to a regular
+  OCI artifact taking the optional `referenceName` into account.
 
 Additional blob handlers might be registered by local incarnations.

--- a/doc/appendix/B/ociArtefact.md
+++ b/doc/appendix/B/ociArtefact.md
@@ -1,10 +1,10 @@
-# `ociArtefact` &#8212; OCI Artefact Access
+# `ociArtifact` &#8212; OCI Artifact Access
 
 
 ### Synopsis
 
 ```
-type: ociArtefact/v1
+type: ociArtifact/v1
 ```
 
 Provided blobs use the following media type:
@@ -14,12 +14,12 @@ Provided blobs use the following media type:
 
 Depending on the repository appropriate docker legacy types might be used.
 
-The artefact content is provided in the [Artefact Set Format](../common/formatspec.md#artefact-set-archive-format).
+The artifact content is provided in the [Artifact Set Format](../common/formatspec.md#artifact-set-archive-format).
 The tag is provided as annotation.
 
 ### Description
 
-This method implements the access of an OCI artefact stored in an OCI registry.
+This method implements the access of an OCI artifact stored in an OCI registry.
 
 ### Specification Versions
 
@@ -31,6 +31,6 @@ The type specific specification fields are:
 
 - **`imageReference`** *string*
 
-  OCI image/artefact reference following the possible docker schemes:
-    - `<repo>/<artefact>:<digest>@<tag>`
-    - `<host>[<port>]/repo path>/<artefact>:<version>@<tag>`
+  OCI image/artifact reference following the possible docker schemes:
+    - `<repo>/<artifact>:<digest>@<tag>`
+    - `<host>[<port>]/repo path>/<artifact>:<version>@<tag>`

--- a/doc/appendix/B/ociBlob.md
+++ b/doc/appendix/B/ociBlob.md
@@ -23,7 +23,7 @@ The type specific specification fields are:
 
 - **`imageReference`** *string*
 
-  OCI repository reference (this artefact name used to store the blob).
+  OCI repository reference (this artifact name used to store the blob).
 
 - **`mediaType`** *string*
 

--- a/doc/appendix/B/s3.md
+++ b/doc/appendix/B/s3.md
@@ -23,7 +23,7 @@ The type specific specification fields are:
 
 - **`region`** (optional) *string*
 
-  OCI repository reference (this artefact name used to store the blob).
+  OCI repository reference (this artifact name used to store the blob).
 
 - **`bucket`** *string*
 

--- a/doc/appendix/C/README.md
+++ b/doc/appendix/C/README.md
@@ -3,35 +3,35 @@
 The signing of a component version is based on content of the 
 [component descriptor](../../specification/elements/README.md#component-descriptor)
 describing a [component version](../../specification/elements/README.md#component-versions),
-the content of the described [artefacts](../../specification/elements/README.md#artefacts) and the
+the content of the described [artifacts](../../specification/elements/README.md#artifacts) and the
 [referenced component versions](../../specification/elements/README.md#aggregation).
 
 A signature of a component version is based on digests of the involved elements.
 Therefore, the there must be a defined way, how to calculate digests for
-artefact content and component descriptors, which be used in a recursive way
+artifact content and component descriptors, which be used in a recursive way
 to handle aggregations.
 
-## Artefact Digest
+## Artifact Digest
 
-Because the content of every artefact is provided in dedicated blob formats by the
-various [access methods](../../specification/elements/README.md#artefact-access), such
+Because the content of every artifact is provided in dedicated blob formats by the
+various [access methods](../../specification/elements/README.md#artifact-access), such
 a digest can be calculated based on this blob. This is the default behaviour.
 Nevertheless, there might be technology specific ways to provide an immutable
-digest for a dedicated type of artefact, independent of the blob format generation
-(typically an archive). For example, an OCI artefact
+digest for a dedicated type of artifact, independent of the blob format generation
+(typically an archive). For example, an OCI artifact
 is always uniquely identified by its manifest digest. This can be exploited
-for the calculation of OCM artefact digests.
+for the calculation of OCM artifact digests.
 
 Together with the digest and its algorithm, for example SHA-256, a
-normalization type is kept for an artefact. This algorithm specifies the way
-the digest is determined. For example, for OCI artefacts, the algorithm
-`ociArtefactDigest/v1` is used by default. This behaviour can be controlled by
+normalization type is kept for an artifact. This algorithm specifies the way
+the digest is determined. For example, for OCI artifacts, the algorithm
+`ociArtifactDigest/v1` is used by default. This behaviour can be controlled by
 appropriate digest handlers. Supported algorithms can be found
-[here](../../specification/formats/artefact_normalization.md).
+[here](../../specification/formats/artifact_normalization.md).
 
-If the digest algorithm `NO-DIGEST` is specified for an artefact,
-this artefact content is not included into the component version digest.
-This is typically configured for source artefacts, which are not deliverable.
+If the digest algorithm `NO-DIGEST` is specified for an artifact,
+this artifact content is not included into the component version digest.
+This is typically configured for source artifacts, which are not deliverable.
 
 ## Component Descriptor Digest
 
@@ -53,11 +53,11 @@ signing-relevant properties, only.
 
 The process and the format is described [here](../../specification/formats/componentdescriptor_normalization.md).
 
-## Artefact Digests
+## Artifact Digests
 
 As described, resources have a digest field to store the content hash. Different resource types will use a different normalisationAlgorithm:
 
- - `ociArtefactDigest/v1`: uses the hash of the manifest of an oci artefact
+ - `ociArtifactDigest/v1`: uses the hash of the manifest of an oci artifact
  - `genericBlobDigest/v1`: uses the hash of the blob
 
 
@@ -76,17 +76,17 @@ The following algorithms are centrally defined and available in the OCM toolset:
 
 - `NO-DIGEST`: Blob content is ignored for the signing process.
 
-  This is a possibility for referencing volatile artefact content.
+  This is a possibility for referencing volatile artifact content.
 - 
 - `genericBlobDigest/v1` (*default*): Blob byte stream digest
 
   This is the default normalization algorithm. It just uses the blob content
-  provided by the access method of an OCM artefact to calculate the digest.
-  It is always used, if no special digester is available for an artefact type.
+  provided by the access method of an OCM artifact to calculate the digest.
+  It is always used, if no special digester is available for an artifact type.
 
-- `ociArtefactDigest/v1`: OCI manifest digest
+- `ociArtifactDigest/v1`: OCI manifest digest
 
-  This algorithm is used for artefact blobs with the media type of an OCI artefact.
-  It just uses the manifest digest of the OCI artefact.
+  This algorithm is used for artifact blobs with the media type of an OCI artifact.
+  It just uses the manifest digest of the OCI artifact.
 
 

--- a/doc/appendix/D/README.md
+++ b/doc/appendix/D/README.md
@@ -6,7 +6,7 @@ Signing of a component version consists of several steps:
 1. digests for all reference component versions are determined and put
    into the dedicated reference element of the component descriptor.
    This is done by recursively following this procedure, but without the signing step.
-2. digests for all described artefacts are determined and put into the dedicated
+2. digests for all described artifacts are determined and put into the dedicated
    element entry in the component descriptor (sources, resources)
 3. the resulting component descriptor is [normalized](../../specification/formats/componentdescriptor_normalization.md)
    and a digest is calculated according to the selected digest algorithm. The resulting
@@ -17,7 +17,7 @@ Signing of a component version consists of several steps:
 
 The digest fields *MUST* be calculated during teh signing process and already existing
 digest fields *CAN NOT* be trusted. Resources have to be accessed and
-a digests has to be determined according to the combination of artefact
+a digests has to be determined according to the combination of artifact
 normalization and digest algorithm and verified against existing digests.
 Component version references have to be followed recursively, calculating the
 digest for the referenced component descriptor. If digests fields for resources or

--- a/doc/appendix/E/README.md
+++ b/doc/appendix/E/README.md
@@ -1,17 +1,17 @@
-# E. Artefact Types
+# E. Artifact Types
 
-The following [artefact types](../../specification/formats/types.md#artefact-types) are centrally defined:
+The following [artifact types](../../specification/formats/types.md#artifact-types) are centrally defined:
 
 | TYPE          | VALUE                           | DESCRIPTION                   |
 | ------------- | ------------------------------- | ----------------------------- |
-| OCI Artefact  | [`ociArtefact`](ociArtefact.md) | A generic OCI artefact following the [open containers image specification](https://github.com/opencontainers/image-spec/blob/main/spec.md) |
+| OCI Artifact  | [`ociArtifact`](ociArtifact.md) | A generic OCI artifact following the [open containers image specification](https://github.com/opencontainers/image-spec/blob/main/spec.md) |
 | OCI Image     | [`ociImage`](ociImage.md)       | An OCI image or image list |
-| Helm Chart    | [`helmChart`](helmChart.md)     | A Helm Chart stored as OCI artefact or as tar blob (`mediaType` tar) |
+| Helm Chart    | [`helmChart`](helmChart.md)     | A Helm Chart stored as OCI artifact or as tar blob (`mediaType` tar) |
 | Blob          | [`blob`](blob.md)               | Any anonymous untyped blob data |
 | Filesystem   | [`fileSystem`](fileSystem.md)    | Some filesystem content (tar, tgz) |
 | GitOps        | [`gitOpsTemplate`](gitOpsTemplate.md) | Filesystem content (tar, tgz) used as GitOps Template, e.g. to set up a git repo used for continuous deployment (for example flux) |
 
-For centrally defined artefact types, there might be special support in the
+For centrally defined artifact types, there might be special support in the
 standard OCM library and tool set. For example, there is a dedicated downloader
 for helm charts providing the filesystem helm chart format regardless of
 the storage method and supported media type.
@@ -26,26 +26,26 @@ This explicitly includes access information, a formal description to describe a
 technical access path, which can be used to gain access to the real technical 
 content. For the component model such content of resources is just seen as
 simple typed blobs. This enables to formally reference blobs in external
-environments, as long as the described [access method](../specification/elements/README.md#artefact-access)
+environments, as long as the described [access method](../specification/elements/README.md#artifact-access)
 is known to the consuming environment. The evaluation of an access specification
 always results in a simple blob representing the content of the described resource.
 This way basically all required blobs can be stored in any supported external blob store.
 
-An [access method](../../specification/elements/README.md#artefact-access) must
-always be able to return a blob representation for the accessed artefact.
-If there are native storage technologies for dedicated artefact types they
+An [access method](../../specification/elements/README.md#artifact-access) must
+always be able to return a blob representation for the accessed artifact.
+If there are native storage technologies for dedicated artifact types they
 must deliver such a blob, also. 
 
 This basically means, whenever a new resource type is supported,
 corresponding blob formats must be defined for this type. Type-agnostic access types, like [`localBlob`](../B/localBlob.md) or [`ociBlob`](../B/ociBlob.md)
 just deal with those blobs, they never need to know anything about their internal 
-format. But specific access methods, e.g. the [`ociArtecat`](../B/ociArtefact.md) 
+format. But specific access methods, e.g. the [`ociArtecat`](../B/ociArtifact.md) 
 method may provide dedicated blob formats.
 
-These blob formats may depend on the combination of artefact type and access type.
+These blob formats may depend on the combination of artifact type and access type.
 Therefore, a blob always has a *mimeType* specifying the technical format.
 
-For every artefact type the possible mime types with their technical format 
+For every artifact type the possible mime types with their technical format 
 specifications must be defined.
 
 When using the component repository to transport content from one repository the
@@ -56,6 +56,6 @@ access information stored along with the described resources may change over tim
 or from environment to environment. But all variants must describe the same
 technical content.
 
-If multiple mime types are possible for blobs, the digest of the artefact content must be immutable to avoud invalidating signatures. Therefore, in such a case, a
-dedicated [blob normalization algorithms](../../specification/formats/artefact_normalization.md) 
+If multiple mime types are possible for blobs, the digest of the artifact content must be immutable to avoud invalidating signatures. Therefore, in such a case, a
+dedicated [blob normalization algorithms](../../specification/formats/artifact_normalization.md) 
 has to be provided for such mime types.

--- a/doc/appendix/E/gitOpsTemplate.md
+++ b/doc/appendix/E/gitOpsTemplate.md
@@ -1,6 +1,6 @@
 # `gitOpstemplate` &#8212; Filesystem Content as GitOps Template
 
 A [filesystem content](fileSystem.md) intended to be used as Git Opts Template.
-Such an artefact should be used in sequence of successive versions
+Such an artifact should be used in sequence of successive versions
 that can be used by a 3-way merge to be merged with an instance
 specific Git Ops Repository content (for example via GitHub Pull Requests).

--- a/doc/appendix/E/helmChart.md
+++ b/doc/appendix/E/helmChart.md
@@ -1,15 +1,15 @@
 # `helmChart` &#8212; Kubernetes Helm Chart
 
-A Kubernetes installation resource representing a Helm chart, either stored as OCI artefact or as tar blob.
+A Kubernetes installation resource representing a Helm chart, either stored as OCI artifact or as tar blob.
 
 ## Format Variants
 
 So far, two technical representations are supported:
 
-- *OCI Artefact*
+- *OCI Artifact*
 
-  If stored as OCI artefact, the access type MUST either be
-  `ociArtefact` or the [OCI artefact blob format](ociArtefact.md#format-variants) must be
+  If stored as OCI artifact, the access type MUST either be
+  `ociArtifact` or the [OCI artifact blob format](ociArtifact.md#format-variants) must be
   used with an appropriate media type.
 
 - *Helm Tar Archive*
@@ -21,5 +21,5 @@ So far, two technical representations are supported:
 
 There is a dedicated downloader available, that always converts
 the helm chart blob into the appropriate filesystem representation
-required by Helm when downloading the artefact using the
+required by Helm when downloading the artifact using the
 command line interface.

--- a/doc/appendix/E/ociArtefact.md
+++ b/doc/appendix/E/ociArtefact.md
@@ -1,9 +1,9 @@
-# `ociArtefact` &#8212; General OCI Artefact or Artefact Index
+# `ociArtifact` &#8212; General OCI Artifact or Artifact Index
 
 ## Format Variants
 
-When provided as a blob, the [Artefact Set Format](../common/formatspec.md#artefact-set-archive-format)
-MUST be used to represent the content of the OCI artefact.
+When provided as a blob, the [Artifact Set Format](../common/formatspec.md#artifact-set-archive-format)
+MUST be used to represent the content of the OCI artifact.
 THis format can be used to store multiple versions of on OCI repository
 in a filesystem-compatible manner. In this scenario only the 
 single version of interest is stored.
@@ -17,7 +17,7 @@ Provided blobs use the following media type:
 
 There is a dedicated uploader available for local blobs.
 It converts a blob with the media type shown above into 
-a regular OCI artefact in an OCI repository.
+a regular OCI artifact in an OCI repository.
 
 It uses the reference hint attribute of the
 [`localBlob` access method](../B/localBlob.md) to determine

--- a/doc/appendix/E/ociImage.md
+++ b/doc/appendix/E/ociImage.md
@@ -1,9 +1,9 @@
 # `ociImage` &#8212; OCI Image or Image Index
 
-An OCI artefact that contains an OCI container image.
+An OCI artifact that contains an OCI container image.
 The content is intended to be used as container image.
 
-A general [ociArtefact](ociArtefact.md) may describe
+A general [ociArtifact](ociArtifact.md) may describe
 any kind of content, depending on the media type of
 its config blob (see also [`helmChart`](helmChart.md)).
 
@@ -12,10 +12,10 @@ image media types.
 
 ## Format Variants
 
-As special case for a general `ociArtefact` is uses
-the [`ociArtefact` blob format](ociArtefact.md#format-variants).
+As special case for a general `ociArtifact` is uses
+the [`ociArtifact` blob format](ociArtifact.md#format-variants).
 
 ## Special Support
 
-As special case for a general `ociArtefact` is uses
-the [`ociArtefact` special support](ociArtefact.md#special-support).
+As special case for a general `ociArtifact` is uses
+the [`ociArtifact` special support](ociArtifact.md#special-support).

--- a/doc/appendix/F/README.md
+++ b/doc/appendix/F/README.md
@@ -1,6 +1,6 @@
 # F. Label Definitions
 
-[Artefacts](../../specification/elements/README.md#artefacts),
+[Artifacts](../../specification/elements/README.md#artifacts),
 [references](../../specification/elements/README.md#aggregation) and
 [component versions](../../specification/elements/README.md#component-versions)
 feature [labels](../../specification/elements/README.md#labels)

--- a/doc/appendix/README.md
+++ b/doc/appendix/README.md
@@ -8,26 +8,26 @@ provided by the Open Component Model.
 [C. Digest Calculation](C/README.md) <br>
 [D. Signature types](E/README.md) <br>
 
-[E. Artefact Types](F/README.md) <br>
+[E. Artifact Types](F/README.md) <br>
 [F. Labels](F/README.md) <br>
 
 The specification is based on 4 basic functional extension points:
 - The storage backend technologies to use to store OCM elements (available
   mapping specifications can be found in [appendix A](A/README.md)).
-- Access to artefact content using different storage technologies. This
+- Access to artifact content using different storage technologies. This
   is described by types access specifications (types with available
   implementations can be found in [appendix B](B/README.md)).
 - Digest calculation for dedicated content technologies requiring digests different
-  from standard byte sequence digests of artefact blobs (defined digest types
+  from standard byte sequence digests of artifact blobs (defined digest types
   can be found in [appendix C](C/README.md)).
 - Defined signing extensions can be found in [appendix D](D/README.md)).
 
 Additionally, there are two extension points for describing semantics
-of artefacts:
-- Formal artefact types describe the technical meaning of an artefact, 
+of artifacts:
+- Formal artifact types describe the technical meaning of an artifact, 
   independent of their technical representation in a blob format (centrally
   defined types are described in [appendix E](E/README.md)).
-- Dynamic attribution of artefacts with additional formal information not
+- Dynamic attribution of artifacts with additional formal information not
   directly described by elements of the Open Component Model is possible
   with labels. The meaning of dedicated label names is globally unique
   (centrally defined label names with their meaning are defined in
@@ -37,11 +37,11 @@ The provided reference implementation provides more functional
 extension points to enrich and extend the functionality of the
 standard library:
 
-- *Artefact Uploaders* are used to implicitly store artefacts of dedicated types
+- *Artifact Uploaders* are used to implicitly store artifacts of dedicated types
   uploaded as local blobs in dedicated repositories.
-- *Artefact Downloaders* are used to map artefact blobs to dedicated formats 
-  for storing an artefact according to its type in the filesystem
-- *Transport Handlers* controlling the handling of artefacts during
+- *Artifact Downloaders* are used to map artifact blobs to dedicated formats 
+  for storing an artifact according to its type in the filesystem
+- *Transport Handlers* controlling the handling of artifacts during
   transportation steps.
 
 These extensions are not covered by this specification, because they are

--- a/doc/appendix/common/formatspec.md
+++ b/doc/appendix/common/formatspec.md
@@ -7,40 +7,40 @@ of an OCI repository.
 
 It is used to describe an OCI repository structure. Therefore, it can be used
 to describe a subset of repositories of an OCI registry with a subset of
-artefacts, that can then be imported again into any OCI registry.
+artifacts, that can then be imported again into any OCI registry.
 
 It is a directory containing
 
-- **`artefact-index.json`** *[Artefact Index](#artefact-index)*
+- **`artifact-index.json`** *[Artifact Index](#artifact-index)*
 
-  This JSON file describes the contained artefact (versions).
+  This JSON file describes the contained artifact (versions).
 
 - **`blobs`** *directory*
 
   The *blobs* directory contains the blobs described by the
-  _artefact index_ as a flat file list. These are layer blobs or artefact
-  blobs for the artefact descriptors. Every file has a filename according
+  _artifact index_ as a flat file list. These are layer blobs or artifact
+  blobs for the artifact descriptors. Every file has a filename according
   to its [digest](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests).
   Hereby the algorithm separator character is replaced by a dot (".").
-  Every file SHOULD be referenced, directly or indirectly, in the artefact
+  Every file SHOULD be referenced, directly or indirectly, in the artifact
   descriptor by a
   [descriptor according the OCI Image Specification](https://github.com/opencontainers/image-spec/blob/main/descriptor.md).
 
-  The artefact index describes the OCI manifests (image manifests and index
+  The artifact index describes the OCI manifests (image manifests and index
   manifests), which refer to further non-manifest blobs.
-  Files not referenced by the artefacts described by the index are ignored.
+  Files not referenced by the artifacts described by the index are ignored.
 
 
 This format might be used in various technical forms: as structure of an
 operating system file system, a virtual file system or as content of
 an archive file. The descriptor SHOULD be the first file if stored in an archive.
 
-## *Artefact Index*
+## *Artifact Index*
 
-The *Artefact Index* is a JSON file describing the artefact content in
+The *Artifact Index* is a JSON file describing the artifact content in
 a file system structure according to this specification.
 
-### *Artefact Index* Property Descriptions
+### *Artifact Index* Property Descriptions
 
 It contains the following properties.
 
@@ -51,80 +51,80 @@ It contains the following properties.
   field will not change. This field MAY be removed in a future version of the
   specification.
 
-- **`index`** *[artefact](#artefact-property-descriptions)*
+- **`index`** *[artifact](#artifact-property-descriptions)*
 
 
-### *Artefact* Property Descriptions
+### *Artifact* Property Descriptions
 
-An artefact consists of a set of properties encapsulated in key-value fields.
+An artifact consists of a set of properties encapsulated in key-value fields.
 
-The following fields contain the properties that constitute an *Artefact*:
+The following fields contain the properties that constitute an *Artifact*:
 
 - **`repository`** *string*
 
-  This REQUIRED property is the _repository_ name of the targeted artefact described by the
+  This REQUIRED property is the _repository_ name of the targeted artifact described by the
   *Common Transport Format*,  conforming to the requirements outlined in the
   [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md).
 
 - **`digest`** *string*
 
-  This REQUIRED property is the _digest_ of the targeted artefact blob in the targeted
-  artefact set, conforming to the requirements outlined in
+  This REQUIRED property is the _digest_ of the targeted artifact blob in the targeted
+  artifact set, conforming to the requirements outlined in
   [Digests](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests).
   Retrieved content SHOULD be verified against this digest when consumed via
   untrusted sources.
 
 - **`tag`** *string*
 
-  This optional property is the _tag_ of the targeted artefact, conforming to
+  This optional property is the _tag_ of the targeted artifact, conforming to
   the requirements outlined in the
   [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md).
 
-  There might be multiple entries in the artefact list referring to the same artefact
+  There might be multiple entries in the artifact list referring to the same artifact
   with different tags. But all used tags for a repository must be unique.
 
 
-## *Artefact Set Archive* Format
+## *Artifact Set Archive* Format
 
-The *Artefact Set Archive* Format describes a file system structure that can be
-used for the representation of a dedicated set of [artefact versions](https://github.com/opencontainers/image-spec)
+The *Artifact Set Archive* Format describes a file system structure that can be
+used for the representation of a dedicated set of [artifact versions](https://github.com/opencontainers/image-spec)
 of an OCI registry for the same OCI repository.
 
-An artefact set can be exported from an OCI repository and imported into another
-OCI repository, it only contains artefacts and tags from a single repository.
+An artifact set can be exported from an OCI repository and imported into another
+OCI repository, it only contains artifacts and tags from a single repository.
 
-In the archive form the artefact set descriptor SHOULD be the first file.
+In the archive form the artifact set descriptor SHOULD be the first file.
 
 The file structure is a directory containing
 
-- **`artefact-set-descriptor.json`** *[oci image index](https://github.com/opencontainers/image-spec/blob/main/image-index.md)*
+- **`artifact-set-descriptor.json`** *[oci image index](https://github.com/opencontainers/image-spec/blob/main/image-index.md)*
 
-  This JSON file describes the contained artefact (version). It MUST be an index manifest.
-  It MUST describe all *[artefacts](https://github.com/opencontainers/image-spec/blob/main/manifest.md)*
+  This JSON file describes the contained artifact (version). It MUST be an index manifest.
+  It MUST describe all *[artifacts](https://github.com/opencontainers/image-spec/blob/main/manifest.md)*
   that should be addressable.
 
 - **`blobs`** *directory*
 
-  The *blobs* directory contains the blobs described by the artefact set descriptor
+  The *blobs* directory contains the blobs described by the artifact set descriptor
   as a flat file list. Every file has a filename according to its
   [digest](https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests).
   Hereby the algorithm separator character is replaced by a dot (".").
-  Every file SHOULD be referenced in the artefact descriptor by a
+  Every file SHOULD be referenced in the artifact descriptor by a
   [descriptor according the OCI Image Specification](https://github.com/opencontainers/image-spec/blob/main/descriptor.md).
 
-  Files not referenced by the artefacts described by the index are ignored.
+  Files not referenced by the artifacts described by the index are ignored.
 
-The artefact set index describes the manifest entries that should be registered
+The artifact set index describes the manifest entries that should be registered
 via the manifest endpoint according to the distribution spec.
 
 ### Extension Models
 
-Any artefact described by this format is addressable only by digests.
+Any artifact described by this format is addressable only by digests.
 The entries in the index are intended to be registered via the manifest
 endpoint according to the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec).
 
 Additionally this specification describes two special annotations, that can be
-set for any described artefact in the annotations attribute of the manifest
+set for any described artifact in the annotations attribute of the manifest
 list entries:
 
 - **`software.ocm/tags`**
@@ -140,26 +140,26 @@ For the annotations of the index itself the following keys are defined:
 
 - **`software.ocm/main`** *digest*
 
-  This annotation describes the digest of the main artefact of the set, if used
-  as blob format for an artefact
+  This annotation describes the digest of the main artifact of the set, if used
+  as blob format for an artifact
 
 This way the format can be used to attach elements according to various extension
 models for the OCI specification:
 
  - *[cosign](https://github.com/sigstore/cosign)*
 
-   For *cosign* additional signatures are represented as dedicated artefacts
-   with special tags establishing the relation to the original artefact they
+   For *cosign* additional signatures are represented as dedicated artifacts
+   with special tags establishing the relation to the original artifact they
    refer to by deriving the tag from the digest of the related object.
 
    This is supported by this format by providing a possibility to describe
    additional tags by an annotation in the index
 
- - [*ORAS*](https://github.com/oras-project/artefacts-spec)
+ - [*ORAS*](https://github.com/oras-project/artifacts-spec)
 
    Here a new third top-level manifest type is introduced, that can be
    stored via the manifest endpoint of the distribution spec. No additional
    tags are required, the relation to the annotated object is established
-   by a dedicated digest based field. Those artefacts can directly be
+   by a dedicated digest based field. Those artifacts can directly be
    described by this format. But language bindings basically have to support
    this additional type.

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -5,8 +5,8 @@
 ## A
 
 
-#### [Access Method](specification/elements/README.md#artefact-access)<a id="accmeth"/>
-a dedicated procedure how to access the content of an [artefact](#artefact) 
+#### [Access Method](specification/elements/README.md#artifact-access)<a id="accmeth"/>
+a dedicated procedure how to access the content of an [artifact](#artifact) 
 described by a [component version](#compvers). It is formally represented by an
 [access method type](#acctype).
 
@@ -15,35 +15,35 @@ the operations an implementation of an [access method](#accmeth) has to support.
 
 #### [Access Method Type](specification/formats/types.md#access-method-types)<a id="acctype"/>
 the type of an [access specification](#accspec) determining the formal procedure
-to use to access the blob content of an [artefact](#artefact).
+to use to access the blob content of an [artifact](#artifact).
 
-#### [Access Specification](specification/elements/README.md#artefact-access)<a id="accspec"/>
+#### [Access Specification](specification/elements/README.md#artifact-access)<a id="accspec"/>
 the specification of the technical access path to the physical blob content of
-an [artefact](#artefact) described by a [component version](#compvers).
+an [artifact](#artifact) described by a [component version](#compvers).
 
 #### [Aggregation](specification/elements/README.md#aggregation)<a id="aggregation"/>
 the ability of the Open Component Model to compose [component versions](#compvers)
 based on other component versions.
 
-#### [Artefact](specification/elements/README.md#artefacts)<a id="artefact"/>
+#### [Artifact](specification/elements/README.md#artifacts)<a id="artifact"/>
 some blob content described  by a [component version](#component-version).
 
-#### [Artefact Digest](specification/elements/README.md#digest-info)<a id="artdigest"/>
-the (logical) digest of an [artefact](#artefact) described by a [component version](#component-version).
+#### [Artifact Digest](specification/elements/README.md#digest-info)<a id="artdigest"/>
+the (logical) digest of an [artifact](#artifact) described by a [component version](#component-version).
 
-#### [Artefact Normalization](specification/formats/artefact_normalization.md)<a id="artnorm"/>
-the transformation of a technical blob content of an [artefact](#artefact) depending
+#### [Artifact Normalization](specification/formats/artifact_normalization.md)<a id="artnorm"/>
+the transformation of a technical blob content of an [artifact](#artifact) depending
 on its [type](#arttype) into a
 serialization-agnostic digest, which is used for signing purposes along a transportation path.
 
-#### [Artefact Reference](specification/elements/README.md#artefact-references)<a id="artref"/>
-a relative or absolute reference to an [artefact](#artefact) described by a 
+#### [Artifact Reference](specification/elements/README.md#artifact-references)<a id="artref"/>
+a relative or absolute reference to an [artifact](#artifact) described by a 
 [component version](#compvers).
 
-#### [Artefact Type](specification/formats/types.md#artefact-types)<a id="arttype"/>
-the formal type of an [artefact](#artefact) described by a
+#### [Artifact Type](specification/formats/types.md#artifact-types)<a id="arttype"/>
+the formal type of an [artifact](#artifact) described by a
 [component version](#compvers). The type implies the logical interpretation of
-the artefact blob.
+the artifact blob.
 
 ## C
 
@@ -88,7 +88,7 @@ the possibility to describe identities of [components](#component),
 
 
 #### Digest <a id="digest"/>
-see [artefact digest](#artdigest) or [component version digest](#compdigest).
+see [artifact digest](#artdigest) or [component version digest](#compdigest).
 
 ## E
 
@@ -111,7 +111,7 @@ see [element identity](#elemid), [component identity](#compid), [component versi
 
 #### [Labels](specification/elements/README.md#labels)<a id="labels"/>
 arbitrary typed information snippets attached to [component versions](#compvers),
-[artefacts](#artefacts) and [references](#compref).
+[artifacts](#artifacts) and [references](#compref).
 
 ## M
 
@@ -126,15 +126,15 @@ described by a [repository type](#repotype).
 the transformation of a technical content depending on its type into a
 serialization-agnostic format, which can be used to calculate an immutable
 digest for signing purposes along a transportation path.
-There are two normalization procedures, [artefact normalization](#artnorm) and
+There are two normalization procedures, [artifact normalization](#artnorm) and
 [component descriptor normalization](#compdescnorm).
 
 ## O
 
 #### [Open Component Model](../README.md)<a id="ocm"/>
 a technology- and location-agnostic description model for software delivery
-artefacts with attached meta-data, providing environment-specific access
-path to described [artefacts](#artefact).
+artifacts with attached meta-data, providing environment-specific access
+path to described [artifacts](#artifact).
 
 #### Operations <a id="ops"/>
 see [repository operations](#repops), [access methods](#accmeth) and
@@ -143,7 +143,7 @@ see [repository operations](#repops), [access methods](#accmeth) and
 ## R
 
 #### Reference <a id="ref"/>
-a reference to an element of the component model, see [artefact reference](#artref)
+a reference to an element of the component model, see [artifact reference](#artref)
 or [component version reference](#compref)
 
 #### [Repository Operations](specification/operations/README.md#repository-operations)<a id="repops"/>
@@ -156,7 +156,7 @@ the type of a [mapping](#mapping) of the [Open Component Model](#ocm) specificat
 to a dedicated storage technology.
 
 #### [Resource](specification/elements/README.md#resources)<a id="resource"/>
-a delivery artefact described by a [component version](#compvers). 
+a delivery artifact described by a [component version](#compvers). 
 
 ## S
 
@@ -165,7 +165,7 @@ a [component version](#compvers) may be signed by an authority, the signature as
 result of such a signing process is stored along with the component version.
 
 #### [Source](specification/elements/README.md#sources)<a id="source"/>
-an artefact described by a [component version](#compvers) containing sources
+an artifact described by a [component version](#compvers) containing sources
 used to generate one or more of the described [resources](#resource).
 
 #### Specification Format
@@ -182,4 +182,4 @@ one OCM repository into another one.
 #### [Type](specification/formats/types.md)<a id="type"/>
 a formal representation of the kind of an [extension point](#ext) of the
 [Open Component Model](#ocm). See [repository type](#repotype),
-[access method type](#acctype), [artefact type](#arttype) [label](#label).
+[access method type](#acctype), [artifact type](#arttype) [label](#label).

--- a/doc/introduction/README.md
+++ b/doc/introduction/README.md
@@ -15,7 +15,7 @@ They don't fit into today's cloud world.
 The result is a fragmented set of homegrown specific tools across products, solutions and services, affecting an
 enterprises' ability to deliver software consistently and compliant to its own or customer operated target environments.
 These specific, overly complex and thus hard to understand CI/CD pipelines, and the inability to instantly
-provide a holistic aggregated view of currently running technical artefacts for each and every production environment
+provide a holistic aggregated view of currently running technical artifacts for each and every production environment
 (including both cloud and on-premise), result in the overall management of software at scale becoming tedious, error-prone
 and ineffective.
 
@@ -23,7 +23,7 @@ and ineffective.
 
 Most prominently, with the general un-alignment of how software is defined and managed,
 it is not possible without additional overhead (like setting up even more processes and tools on top) to manage
-the complete lifecycle of all solutions, services or individual deployment artefacts running in any
+the complete lifecycle of all solutions, services or individual deployment artifacts running in any
 given landscape. Even worse, when trying to set up new landscapes, it becomes a nightmare to successfully orchestrate,
 deploy and configure the needed software components in the new environments.
 
@@ -33,18 +33,18 @@ not improve and will only get worse over time.
 
 ## How can this improve?
 The major problem at hand here is the absence of one aligned software component model, consistently used across the
-enterprise, to manage compliant software components and their technical artefacts. Such
+enterprise, to manage compliant software components and their technical artifacts. Such
 a model would help not only with streamlined deployments to public and private cloud environments, but also in various
 other areas of lifecycle management like compliance processes and reporting. This software component model must describe
-all technical artefacts of a software product, and establish an ID for each component, which should then consistently be
+all technical artifacts of a software product, and establish an ID for each component, which should then consistently be
 used across all lifecycle management tasks.
 
-Here, it is also crucial to understand that setting up local environments often requires the use of artefacts stored local to the environment.
-This is especially true for restricted or private clouds, in which it is usually not possible to access artefacts from
-their original source location (due to restricted internet access), leading to the fact that artefacts need to be
+Here, it is also crucial to understand that setting up local environments often requires the use of artifacts stored local to the environment.
+This is especially true for restricted or private clouds, in which it is usually not possible to access artifacts from
+their original source location (due to restricted internet access), leading to the fact that artifacts need to be
 transported into these environments. This local deployment scenario requires that software components must clearly
-separate their ID from the location of their technical artefacts, so that this technical location may change, without
-changing the ID. At the same time the environment-local location of the artefacts must be retrievable using this identity.
+separate their ID from the location of their technical artifacts, so that this technical location may change, without
+changing the ID. At the same time the environment-local location of the artifacts must be retrievable using this identity.
 
 At its heart, the model has to be technology-agnostic, so that not only modern containerized cloud software,
 but also legacy software is supported, out-of-the-box. It simply has to be acknowledged that companies are not able to
@@ -61,24 +61,24 @@ management of software, is a must.
 
 Operating software installations/products, both for cloud and on-premises, covers many aspects:
 
-- How, when and where are the technical artefacts created?
-- How are technical artefacts stored and accessed?
-- Which technical artefacts are to be deployed?
+- How, when and where are the technical artifacts created?
+- How are technical artifacts stored and accessed?
+- Which technical artifacts are to be deployed?
 - How is the configuration managed?
 - How and when are compliance checks, scanning etc. executed?
-- When are technical artefacts deployed?
-- Where and how are those artefacts deployed?
+- When are technical artifacts deployed?
+- Where and how are those artifacts deployed?
 - Which other software installations are required and how are they deployed and accessed?
 - etc.
 
 The overall problem domain has a complexity that makes it challenging to be solved as a whole.
 However, the problem domain can be divided into two disjoint phases:
 
-- production of technical artefacts
-- deployment and lifecycle management of technical artefacts
+- production of technical artifacts
+- deployment and lifecycle management of technical artifacts
 
-The produced artefacts must be stored somewhere such that they can be accessed and collected for the deployment.
-The OCM defines a standard to describe which technical artefacts belong to a software installation and how to
+The produced artifacts must be stored somewhere such that they can be accessed and collected for the deployment.
+The OCM defines a standard to describe which technical artifacts belong to a software installation and how to
 access them which could be used at the interface between production and the deployment/lifecycle management phase.
 
 The OCM provides a common standard for the coupling of
@@ -88,16 +88,16 @@ The OCM provides a common standard for the coupling of
 - transport
 - deployment or
 - other lifecycle-management aspects
-based on a well-defined description of software-artefacts, their types and the access to their physical content.
+based on a well-defined description of software-artifacts, their types and the access to their physical content.
 
 In that sense, the OCM provides the basis to
 - exchange information about software in a controlled manner by defining a location- and technology-agnostic reference
-  framework to identify software artefacts
-- enable access to local technical artefacts via these IDs
-- verify the authenticity of the artefact content found in an actual environment.
+  framework to identify software artifacts
+- enable access to local technical artifacts via these IDs
+- verify the authenticity of the artifact content found in an actual environment.
 
 If software installations are described using the OCM, e.g. a scanning tool could use this to collect all technical
-artefacts it needs to check and store findings under the globally unique and location-agnostic identities provided by the model.
+artifacts it needs to check and store findings under the globally unique and location-agnostic identities provided by the model.
 This information can be stored along with the component versions and exchanged with other tools without loosing its meaning.
 If the technical resources of different software installations are described with different
 formalisms, such tools must provide interfaces and implementations for all if them and data exchange becomes a nightmare.
@@ -108,12 +108,12 @@ a software installation is available.
 
 The identity scheme provided by the OCM acts as some kind of Lingua Franca, enabling
 a tool ecosystem to describe, store and exchange information even across environments without
-loosing its meaning in relation to the described software artefacts and groupings.
+loosing its meaning in relation to the described software artifacts and groupings.
 
 The core OCM does not make any assumptions about the
 
-- kinds of technical artefacts (e.g. docker images, helm chart, binaries etc., git sources)
-- technology how to store and access technical artefacts (e.g. as OCI artefacts in an OCI registry)
+- kinds of technical artifacts (e.g. docker images, helm chart, binaries etc., git sources)
+- technology how to store and access technical artifacts (e.g. as OCI artifacts in an OCI registry)
 
 OCM is a technology-agnostic specification and allows [implementations](../specification/extensionpoints/README.md) to provide support
 for exactly those technical aspects as an extension of the basic model. The description formalism is even valid and can (at least partly)
@@ -121,5 +121,5 @@ formally processed, if not all specified aspects are covered by an actual implem
 
 It consists of two major elements:
 
-- [*Component Versions*](component_versions.md) are used to describe sets of delivery artefacts.
+- [*Component Versions*](component_versions.md) are used to describe sets of delivery artifacts.
 - [*Component Repositories*](component_repository.md) are used to store component versions.

--- a/doc/introduction/component_versions.md
+++ b/doc/introduction/component_versions.md
@@ -7,29 +7,29 @@ As a result of the development phase, **component versions** are created, e.g. w
 The *component* itself just describes a globally unique identity with a dedicated 
 meaning (the purpose a dedicated version of this component can be used for). The 
 *component version* describes dedicated versions of a component with all the
-concrete artefact required to install this version.
+concrete artifact required to install this version.
 
 In this sense a component version is a software-bill-of-delivery (SBOD). It describes
-delivery and installation artefacts together with metadata. It does not contain
-formal descriptions of the decomposition of such artefacts, like packages or modules
-used to compose/build an artefact (typically meant with the term SBOM).
+delivery and installation artifacts together with metadata. It does not contain
+formal descriptions of the decomposition of such artifacts, like packages or modules
+used to compose/build an artifact (typically meant with the term SBOM).
 
-A component version consists of a set of [technical artefacts](../specification/elements/README.md#artefact-access), e.g. docker images, helm charts, binaries, configuration data etc. Such artefacts are called [**resources**](../specification/elements/README.md#resources).
+A component version consists of a set of [technical artifacts](../specification/elements/README.md#artifact-access), e.g. docker images, helm charts, binaries, configuration data etc. Such artifacts are called [**resources**](../specification/elements/README.md#resources).
 Resources are usually build or packaged from something, e.g. code in a git repo,  named [**sources**](../specification/elements/README.md#sources).
 
 In the Open Component Model a component version is described by a [**Component Descriptor**](../specification/elements/README.md#component-descriptor). 
 It describes the resources, sources and aggregated other component versions belonging to a particular component version.
 
-It not only describes identities for contained artefacts, but the real truth, by 
-additionally carrying access information for the technical content behind an artefact. Therefore, given the access to a component descriptor also provides access
-to the content of the described artefacts.
+It not only describes identities for contained artifacts, but the real truth, by 
+additionally carrying access information for the technical content behind an artifact. Therefore, given the access to a component descriptor also provides access
+to the content of the described artifacts.
 
 The model definition provides means to handle the [transport](transports.md) of
-component versions from one environment into another by adapting the artefact 
+component versions from one environment into another by adapting the artifact 
 access information, accordingly, without invalidation potential signatures. Therefore, the access information given by
 a component descriptor always provides environment local information, which
 enables tools working (e.g. deployment tools) with it to always access described
-artefacts from locations applicable for the actual environment.
+artifacts from locations applicable for the actual environment.
 
 For the three components in our sample software product mentioned above, one component descriptor exists for every component version, the frontend, backend and monitoring stack.
 
@@ -37,18 +37,18 @@ Not all component version combinations of frontend, backend and monitoring are c
 
 For our example we could introduce a component for the overall software product. A particular version of this product component is again described by a component descriptor, which contains references to particular component version for the frontend, backend and monitoring stack.
 
-This is only an example how to describe a particular product version with OCM as a component with one version with references to versions of other components, which itself could have such references and so on. You are not restricted to this approach, i.e. you could still just maintain a list of component version combinations which build a valid product release. But OCM provides you a simple approach to specify what belongs to a product version. Starting with the Component Descriptor for a product version and following the component references, you could collect all artefacts, belonging to this product version.
+This is only an example how to describe a particular product version with OCM as a component with one version with references to versions of other components, which itself could have such references and so on. You are not restricted to this approach, i.e. you could still just maintain a list of component version combinations which build a valid product release. But OCM provides you a simple approach to specify what belongs to a product version. Starting with the Component Descriptor for a product version and following the component references, you could collect all artifacts, belonging to this product version.
 
 **Summary:** \
 *Component Versions* are the central concept of OCM. A *Component Version* describes what belongs to a particular version of a software component and how to access it. This includes:
 
-- resources, i.e. technical artefacts like binaries, docker images, ...
+- resources, i.e. technical artifacts like binaries, docker images, ...
 - sources like code in github
 - references to other software component versions
 
 ### Component Name and Version
 
-Every *Component Version* has a name and version, also called component name and component version. Name and version are the identifier for a *Component Version* and therefor for the artefact set described by it.
+Every *Component Version* has a name and version, also called component name and component version. Name and version are the identifier for a *Component Version* and therefor for the artifact set described by it.
 
 ```
 meta:
@@ -192,10 +192,10 @@ component:
     relation: external  # -> located in an external registry
     access:             # -> access information how to locate this resource
       imageReference: gcr.io/google_containers/echoserver:1.10
-      type: ociArtefact
+      type: ociArtifact
     digest:             # -> digest of this resource used for signing
       hashAlgorithm: sha256
-      normalisationAlgorithm: ociArtefactDigest/v1
+      normalisationAlgorithm: ociArtifactDigest/v1
       value: cb5c1bddd1b5665e1867a7fa1b5fa843a47ee433bbb75d4293888b71def53229
   - name: chart         # -> name of this resource
     version: 0.1.0-dev  # -> version of this resource
@@ -203,10 +203,10 @@ component:
     relation: local     # -> located in the local registry
     access:             # -> access information how to locate this resource
       imageReference: ghcr.io/jensh007/ctf/github.com/open-component-model/ocmechoserver/echoserver:0.1.0
-      type: ociArtefact
+      type: ociArtifact
     digest:             # -> digest of this resource used for signing
       hashAlgorithm: sha256
-      normalisationAlgorithm: ociArtefactDigest/v1
+      normalisationAlgorithm: ociArtifactDigest/v1
       value: 385531bf40fc2b93e1693c0270250deb8da488a8f6f8dcaa79b0ab2bf1041c0b
   - name: package      # -> name of this resource
     version: 0.1.0-dev # -> version of this resource

--- a/doc/introduction/transports.md
+++ b/doc/introduction/transports.md
@@ -1,29 +1,29 @@
 # Transport of Component Versions
 
-In some scenarios ist is required to transfer artefacts required to install a software product in different locations. For example:
+In some scenarios ist is required to transfer artifacts required to install a software product in different locations. For example:
 
 * deployments have to be performed in isolated environments without Internet access
 * replication between locations in different regions or environments, sometimes far away.
 
-For such scenarios it is required to transfer delivered artefacts consistently.
-You need a reliable list of delivery artefacts required at the target side to install
+For such scenarios it is required to transfer delivered artifacts consistently.
+You need a reliable list of delivery artifacts required at the target side to install
 the software product.
 
 What a coincidence, this is exactly what is describes by the Open Component Model.
-Following the transitive component version references of a root [component version](component_versions.md) describing your software product, a complete list of the required artefacts cabe be determined.
+Following the transitive component version references of a root [component version](component_versions.md) describing your software product, a complete list of the required artifacts cabe be determined.
 
 Therefore, the description model provided by OCM can easily be used to provide
 a transport tool, able to transport the complete closure of a component version from
 one environment to another. To support this, a component version includes the
-access information for the described artefacts. This can be used by the transport 
+access information for the described artifacts. This can be used by the transport 
 tool to access the content and to provide it in the target environment.
-If no applicable storage system for the dedicated artefact type according to its
+If no applicable storage system for the dedicated artifact type according to its
 access method, it can be stored as local blob along with the component descriptor 
 directly in the [component repository](component_repository.md).
 The descriptor version store din the target repository has to be adapted accordingly 
-to reflect the new environment-local locations of the described artefacts.
+to reflect the new environment-local locations of the described artifacts.
 This is a special feature of the OCM, to provide modifiable access information for 
-the described artefacts.
+the described artifacts.
 
 The transport target might even be an [archive or filesystem directory](../appendix/A/CTF/README.md).
 This enables the transport of OCM content into fenced environments via a portable
@@ -37,12 +37,12 @@ A transport might be done in several ways
   referenced versions have to be transferred, also. Therefore, a recursive transport
   is required.
 
-- artefacts by-value or by-reference.
+- artifacts by-value or by-reference.
 
   It is possible to transfer component version as they are. This means, only the 
-  component version meta information including the component descriptor and the already existing local blobs are transferred, but referenced artefacts are kept in their locations.
-  If the transport is done by-value the content of the referenced artefacts is transferred, also.
+  component version meta information including the component descriptor and the already existing local blobs are transferred, but referenced artifacts are kept in their locations.
+  If the transport is done by-value the content of the referenced artifacts is transferred, also.
   By default, the content is transformed to a blob representation which is stored as [local blob](component_repository.md#local-blobs) along with the component descriptor in the target repository.
 
   Via upload handlers, it is possible to propagate imported content into its native
-  repository technologies. By default, OCI artefacts will be transferred to regular OCI artefacts, again, if the target OCM repository is based on an OCI registry.
+  repository technologies. By default, OCI artifacts will be transferred to regular OCI artifacts, again, if the target OCM repository is based on an OCI registry.

--- a/doc/scenarios/structuring/README.md
+++ b/doc/scenarios/structuring/README.md
@@ -9,9 +9,9 @@ component comprising the other three components.
 As a result of the development phase, [**component versions**](../../specification/elements/README.md#component-versions)
 are created, e.g. when you make a new release of a component.
 
-A component version consists of a set of technical [artefacts](../../specification/elements/README.md#artefacts),
+A component version consists of a set of technical [artifacts](../../specification/elements/README.md#artifacts),
 e.g. docker images, helm charts, binaries, configuration data etc.
-Such artefacts are called **resources** in this specification.
+Such artifacts are called **resources** in this specification.
 
 Resources are usually build from something, e.g. code in a git repo,
 named **sources** in this specification.
@@ -36,4 +36,4 @@ A particular version of this product component is again described by a
 *Component Descriptor*, which contains references to particular
 *Component Descriptors* for the frontend, backend and monitoring.
 
-This is only one example how to describe a particular product version with OCM as a component with one *Component Descriptor* having references to other *Component Descriptors*, which itself could have such references and so on. You are not restricted to this approach, i.e. you could still just maintain a list of component version combinations which build a valid product release. But OCM provides you a simple approach to specify what belongs to a product version. Starting with the *Component Descriptor* for a product version and following the component references, you could collect all artefacts, belonging to this product version.
+This is only one example how to describe a particular product version with OCM as a component with one *Component Descriptor* having references to other *Component Descriptors*, which itself could have such references and so on. You are not restricted to this approach, i.e. you could still just maintain a list of component version combinations which build a valid product release. But OCM provides you a simple approach to specify what belongs to a product version. Starting with the *Component Descriptor* for a product version and following the component references, you could collect all artifacts, belonging to this product version.

--- a/doc/specification/elements/README.md
+++ b/doc/specification/elements/README.md
@@ -1,7 +1,7 @@
 # 2.1 Model Structure and Elements
 
 The Open Component Model provides a formal description of
-delivery artefacts for dedicated semantics that are accessible
+delivery artifacts for dedicated semantics that are accessible
 in some kind of repository.
 
 This leads to the following major elements that must be specified
@@ -12,16 +12,16 @@ as part of the Open Component Model specification
   - [Components](#components)
   - [Component Versions](#component-versions)
     - [Component Descriptor](#component-descriptor)
-    - [Composing the Artefact Set](#composing-the-artefact-set)
+    - [Composing the Artifact Set](#composing-the-artifact-set)
     - [Identities](#identities)
     - [Labels](#labels)
-    - [Artefacts](#artefacts)
+    - [Artifacts](#artifacts)
       - [Sources](#sources)
       - [Resources](#resources)
-      - [Artefact Access](#artefact-access)
+      - [Artifact Access](#artifact-access)
     - [Aggregation](#aggregation)
-    - [Artefact References](#artefact-references)
-      - [Absolute Artefact References](#absolute-artefact-references)
+    - [Artifact References](#artifact-references)
+      - [Absolute Artifact References](#absolute-artifact-references)
   - [Signatures](#signatures)
         - [Digest Info](#digest-info)
         - [Signature Info](#signature-info)
@@ -82,8 +82,8 @@ based on this DNS name, must include the owner prefix of the providing
 organization, e.g. `github.com/my-org`.
 
 The component acts as a namespace to host multiple [*Component Versions*](#component-versions),
-which finally describe dedicated technical artefact sets, which describe the
-software artefacts required to run this tool.
+which finally describe dedicated technical artifact sets, which describe the
+software artifacts required to run this tool.
 
 *Example:*
 
@@ -97,7 +97,7 @@ by the Gardener team developing the component `external-dns-management`.
 ## Component Versions
 
 A *Component Version* is a concrete instance of a [Component](#components).
-As such it describes a concrete set of (software) [Artefacts](#Artefacts)
+As such it describes a concrete set of (software) [Artifacts](#Artifacts)
 adhering to the semantic assigned to the containing [Component](#components)
 This semantic is subsumed by the identity of the component and defined by its owner.
 
@@ -106,7 +106,7 @@ and a version name following the [semantic versioning](https://semver.org)
 specification. Component versions can be described by a dedicated [textual denotation](../denotations/README.md#component-versions)
 (e.g. `github.com/gardener/external-dns-management:0.15.1`).
 
-So, all versions provided for a component should provide software artefacts
+So, all versions provided for a component should provide software artifacts
 with the semantic defined by the component. For example, for a component
 pretending to be a Kubernetes DNS Controller, all provided versions should
 provide versions of a DNS Controller, and not an ingress controller.
@@ -119,21 +119,21 @@ A *Component Descriptor* is used to describe a dedicated component version.
 It is a YAML file with the structure defined [here](../formats/compdesc/README.md)
 
 The main purpose of a component version is to describe a set of delivery
-[artefacts](#artefacts). Such an artefact set is composed with two
+[artifacts](#artifacts). Such an artifact set is composed with two
 mechanisms:
-1) Artefacts can be directly described by a component descriptor
-2) Artefacts described by another component version can be included into
-   the local artefact set by describing a [reference](#aggregation) to this
+1) Artifacts can be directly described by a component descriptor
+2) Artifacts described by another component version can be included into
+   the local artifact set by describing a [reference](#aggregation) to this
    component version.
 
-Those artefact composing elements all feature a common [set of attributes](#composing-the-artefact-set),
+Those artifact composing elements all feature a common [set of attributes](#composing-the-artifact-set),
 which are used to uniquely [identify the elements](#identities) in the context
 of their component
 descriptor. Additionally, they provide a possibility to formally enrich the
 information attached to an element by using an arbitrary number of
 appropriately named labels without the need for explicit dedicated model
 attributes (for example, attaching hints for the triage of identified
-vulnerabilities for this artefact).
+vulnerabilities for this artifact).
 
 A component descriptor describes:
 - a history of [Repository Contexts](#repository-contexts) describing
@@ -148,15 +148,15 @@ A component descriptor describes:
 - an optional set of [Signatures](#signatures) provided by some authority
   to confirm some state or origin of the component version
 
-### Composing the Artefact Set
+### Composing the Artifact Set
 
 There are several elements in a [component descriptor](#component-descriptor),
-which can be used to compose the artefact set finally described by a component
+which can be used to compose the artifact set finally described by a component
 version.
 
-- elements, which directly describe an [artefact](#artefacts) as part of the
+- elements, which directly describe an [artifact](#artifacts) as part of the
   component descriptor.
-- [references](#aggregation), which can be used to include artefact sets described
+- [references](#aggregation), which can be used to include artifact sets described
   by other components.
 
 All those descriptive elements share a common basic attribute set.
@@ -195,7 +195,7 @@ The element identity is composed by the following formal fields of an element:
   It basically also expresses the meaning or purpose of the element in the
   context of the component version. But it might be the
   case that multiple elements should be used for the same purpose. For example,
-  a component version is used to describe multiple versions of an artefact,
+  a component version is used to describe multiple versions of an artifact,
   which should be selected for different environment versions for deployment.
   Then, they could share the same name, to be able to easily find all those
   elements. In such a case the name is not sufficient to uniquely identify
@@ -214,12 +214,12 @@ The element identity is composed by the following formal fields of an element:
   If given, all those attributes contribute to the identity of the element
   and must be given to uniquely identify an element.
 
-Using multiple attributes of an artefact for its identity makes it easier to formally
-describe the identity and to select a dedicated artefact from the set of
-described artefacts. It avoids the need to
+Using multiple attributes of an artifact for its identity makes it easier to formally
+describe the identity and to select a dedicated artifact from the set of
+described artifacts. It avoids the need to
 marshal a dedicated identity scheme for an intended usage scenario into a
 single attribute value. Instead, different attributes can be used to represent
-the dedicated selection dimensions. Selecting all artefacts for a partial set
+the dedicated selection dimensions. Selecting all artifacts for a partial set
 of constraints is then just a partial match of the set of identity attributes.
 
 For example:
@@ -231,10 +231,10 @@ attributes this can easily be modeled by using
 - the `version` attribute for the image version
 - and an extra identity attribute for the intended Kubernetes Version.
 
-Then you don't need to derive artificially unique artefact names, instead
-the identity of the artefact can naturally be composed by using appropriate
-attributes. Selecting all artefacts for a dedicated purpose is possible
-by selecting all artefacts with the appropriate `name` attribute, without the
+Then you don't need to derive artificially unique artifact names, instead
+the identity of the artifact can naturally be composed by using appropriate
+attributes. Selecting all artifacts for a dedicated purpose is possible
+by selecting all artifacts with the appropriate `name` attribute, without the
 need of parsing an artificial structure imprinted on the name attribute.
 
 <div align="center">
@@ -252,7 +252,7 @@ model element, which do not have static formal fields in the
 [component descriptor](#component-descriptor). Its usage is
 left to users of the component model, or better to the used toolsets
 looking at component versions (for example: a scanning environment,
-used to scan artefacts for vulnerabilities, uses a dedicated label
+used to scan artifacts for vulnerabilities, uses a dedicated label
 to control its behavior).
 
 To be able to evaluate labels used by dedicated tool environments for any
@@ -273,11 +273,11 @@ Labels are described by the element field
 
 A component version describes several kinds of elements.
 
-- [Artefacts](#artefacts) represent technical content. The appear in two different
+- [Artifacts](#artifacts) represent technical content. The appear in two different
   flavors:
   - [Sources](#sources) describe the sources a [component version](#component-versions)
     has been composed/geerated from.
-  - [Resources](#resources) describe the delivery artefacts contained in the
+  - [Resources](#resources) describe the delivery artifacts contained in the
     [component version](#component-versions).
 - [References](#aggregation) describe the aggragation of other
   [component version](#component-versions).
@@ -286,24 +286,24 @@ All those described element feature a common set of meta data consisting of
 of the [element identity](#identities) and [labels](#labels), which can be used
 to attach formalized information, which is not defined the open component model.
 
-### Artefacts
+### Artifacts
 
-An *Artefact* is a blob containing some data in some technical format.
-Every artefact described by the component version has
+An *Artifact* is a blob containing some data in some technical format.
+Every artifact described by the component version has
 - an [Identity](#identities) in the context of the component version
-- a dedicated globally unique [type](../formats/types.md#artefact-types) representing
+- a dedicated globally unique [type](../formats/types.md#artifact-types) representing
   the kind of content and how it can be used
 - a set of [Labels](#labels) to assign arbitrary kinds of information to the
   component version, which is not formally defined by the Open Component Model.
-- a formal description of the [Access Specification](#artefact-access) ,
-  which can be used to technically access the content of the artefact in form of
-  a blob with a format defined by the artefact type. If there are multiple variants
+- a formal description of the [Access Specification](#artifact-access) ,
+  which can be used to technically access the content of the artifact in form of
+  a blob with a format defined by the artifact type. If there are multiple variants
   possible for the blob format, the access specification must be able to
   describe an optional media type. Applying an access specification always
   yields a media type. It might be implicitly provided the [implementation of
   an access method](../operations/README.md#access-method-operations) or explicitly provided by the
   access specification.
-- a (optional) digest of the artefact that is immutable during transport steps.
+- a (optional) digest of the artifact that is immutable during transport steps.
 
 Those attributes are described by formal fields of the element description
 in the component descriptor:
@@ -312,8 +312,8 @@ in the component descriptor:
 
 - **`type`** (required) *string*
 
-  The [type of an artefact](../formats/types.md#artefact-types) uniquely specifies the
-  logical interpretation of an artefact, its kind, independent of its
+  The [type of an artifact](../formats/types.md#artifact-types) uniquely specifies the
+  logical interpretation of an artifact, its kind, independent of its
   concrete technical representation.
 
 - **`labels`** (optional) *[]label*
@@ -323,22 +323,22 @@ in the component descriptor:
 
 - **`access`** (required) *access specification*
 
-  The [access specification](../formats/types.md#access-method-types) for the actual artefact.
+  The [access specification](../formats/types.md#access-method-types) for the actual artifact.
   The specification is typed. The type determines an access method to use
-  to access the artefact blob. This type determines the technical procedure
-  to use to access the artefact blob as well as the specification of the
+  to access the artifact blob. This type determines the technical procedure
+  to use to access the artifact blob as well as the specification of the
   attributes that are required by this procedure to be able to identify a
   dedicated target blob.
 
-The Open Component Model distinguishes two kinds of artefacts:
-- [*Sources*](#sources) are optional artefacts that contain the sources, which
+The Open Component Model distinguishes two kinds of artifacts:
+- [*Sources*](#sources) are optional artifacts that contain the sources, which
   were used to generate the deployment-relevant *Resources*
-- [*Resources*](#resources) are artefacts that finally make up the deployment
-  relevant set of artefacts
+- [*Resources*](#resources) are artifacts that finally make up the deployment
+  relevant set of artifacts
 
 #### Sources
 
-A *Source* is an [Artefact](#artefacts), which describes the sources that were
+A *Source* is an [Artifact](#artifacts), which describes the sources that were
 used to generate one or more of the [Resources](#resources) described by the
 [component descriptor](#component-descriptor). This information might be used
 by scanner tools to extract more information about then final binaries.
@@ -347,7 +347,7 @@ Source elements do not have specific additional formal attributes.
 
 #### Resources
 
-A *Resource* is a delivery [Artefact](#artefacts),
+A *Resource* is a delivery [Artifact](#artifacts),
 intended for deployment into a runtime environment, or describing additional
 content, relevant for a deployment mechanism. For example, installation procedures
 or meta-model descriptions controlling orchestration and/or deployment mechanisms.
@@ -356,12 +356,12 @@ mechanism on top of the Open Component Model can be found [here](../../scenarios
 
 The Open Component Model makes absolutely no assumptions, about how content described
 by the model is finally deployed or used. All this is left to external tools and tool
-specific deployment information is formally represented as other artefacts with
+specific deployment information is formally represented as other artifacts with
 an appropriate dedicated own type.
 
-In addition to the common [artefact](#artefacts) information, a resource
+In addition to the common [artifact](#artifacts) information, a resource
 may optionally describe a reference to the [source](#sources) by specifying
-its artefact identity.
+its artifact identity.
 
 A resource uses the following additional formal fields:
 
@@ -389,10 +389,10 @@ A resource uses the following additional formal fields:
       to attach more information about the part or kind of usage of the sources.
 
 
-#### Artefact Access
+#### Artifact Access
 
 The technical access to the physical content of an
-[artefact](#artefacts) described as
+[artifact](#artifacts) described as
 part of a [Component Version](#component-versions) is expressed by an
 [*Access Specification*](../formats/formats.md#access-specifications).
 It describes the [type](../formats/types.md#access-method-types) of
@@ -400,18 +400,18 @@ the *access method* and the type-specific access path to the content in the
 [repository context](#repository-contexts) the component descriptor has been
 retrieved from. In a concrete execution environment the *Access Method Type*
 is mapped to a concrete access method implementation to execute the procedure
-to finally access the content of an artefact.
+to finally access the content of an artifact.
 
-The content of a described artefact is accessible by applying its
+The content of a described artifact is accessible by applying its
 global identity triple to the following procedure:
 
 - [lookup](../operations/README.md#mandatory-operations) of a [component version](#component-versions)) and its
   [component descriptor](#component-descriptor) by using its
   component identity and version name in
   the desired [repository context](#repository-contexts)
-- identify the artefact by its local [identity](#identities) (distinguish between [source](#sources)
+- identify the artifact by its local [identity](#identities) (distinguish between [source](#sources)
   and [resource](#resources))
-- [apply](../operations/README.md#access-method-operations) the described [access method](#artefact-access)
+- [apply](../operations/README.md#access-method-operations) the described [access method](#artifact-access)
 
 <div align="center">
 <img src="ocmresourceaccess.png" alt="Structure of OCM Specification" width="800"/>
@@ -424,9 +424,9 @@ by adding a *Reference* to the component version.
 
 A component version reference describes only the component version and no location or OCM
 repository. It is always evaluated in the actual repository context.
-This means, that the artefact set described by the referenced component version
-is added to the local artefact set described by the component version defining
-the reference. To keep a unique addressing scheme, like [artefacts](#artefacts),
+This means, that the artifact set described by the referenced component version
+is added to the local artifact set described by the component version defining
+the reference. To keep a unique addressing scheme, like [artifacts](#artifacts),
 references have an [identity](#identities).
 
 #### Component Version Reference
@@ -439,20 +439,20 @@ following additional formal fields:
   The identity of the component whose version is referenced.
   The elements common version field is required in this usage context.
 
-### Artefact References
+### Artifact References
 
 Following the chain of [references](#aggregation), starting from an initial
 [component version](#component-versions),
-any local or non-local artefact can be addressed relative to a component
-version by a possibly empty sequence (for a local artefact) of reference
-[identities](#identities)) followed by the artefact identity in the context of the finally
+any local or non-local artifact can be addressed relative to a component
+version by a possibly empty sequence (for a local artifact) of reference
+[identities](#identities)) followed by the artifact identity in the context of the finally
 reached component version.
 
-Such a composite, consisting of an artefact identity and a sequence of reference
+Such a composite, consisting of an artifact identity and a sequence of reference
 identities is called relative *Source Reference* or *Resource Reference*.
-It can be used in artefacts described by a [component version](#component-versions)
-to refer to other artefacts described by the same component version containing the
-artefact hosting the relative reference.
+It can be used in artifacts described by a [component version](#component-versions)
+to refer to other artifacts described by the same component version containing the
+artifact hosting the relative reference.
 
 *Example:*
 
@@ -498,14 +498,14 @@ This kind of relative access description is location-agnostic, meaning, independ
 of the [repository context](#repository-contexts) used to access
 the initial component version and resource. The stored description only
 includes identities provided by the model. They can then be evaluated in a
-dedicated repository context to finally obtain the artefact content
+dedicated repository context to finally obtain the artifact content
 (or location) in the actually used environment (for example, after
 transportation into a fenced environment).
 
 Depending on the transport history of the component version, the
-correct artefact location valid for the actual environment is used.
+correct artifact location valid for the actual environment is used.
 
-#### Absolute Artefact References
+#### Absolute Artifact References
 
 A relative reference can be extended to an location-agnostic absolute reference by extending
 the pair by a third value, a component version identity.
@@ -513,20 +513,20 @@ the pair by a third value, a component version identity.
 
 <div align="center">
 
-( *&lt;Component Version>* , *&lt;Reference Path> {* , *&lt;Local Artefact Identity> }* )
+( *&lt;Component Version>* , *&lt;Reference Path> {* , *&lt;Local Artifact Identity> }* )
 
 </div>
 
 In a dedicated interpretation environment such a location-agnostic reference can again be
 transferred into a location-specific reference by adding a [repository-context](#repository-contexts).
 
-Such a reference can then be used to finally address the content of this artefact by the
+Such a reference can then be used to finally address the content of this artifact by the
 following procedure:
 
 - gain access to the OCM [repository](#repositories) described by the repository context.
 - gain access to the [component version](#component-versions), respectively the [component descriptor](#component-descriptor),
   by a [lookup operations](../operations/README.md#mandatory-operations)
-- follow the [resolution procedure for the relative artefact reference](#artefact-access).
+- follow the [resolution procedure for the relative artifact reference](#artifact-access).
 
 ## Signatures
 
@@ -577,14 +577,14 @@ A digest is specified by the following fields:
   descriptor is transformed into a normalized form. The method to do so
   is specified by the normalization algorithm.
 
-  Even artefact blobs can be normalized, for example the technical representation
+  Even artifact blobs can be normalized, for example the technical representation
   of an OCI image may depend on the access method. But the digest should be independent
   of the technical representation. The default is to just use the blob digest,
   but for OCI images the digest of the image manifest is used, regardless of the
   technical representation.
 
   This is handled by *Digest Handlers*, which can be defined for dedicated
-  artefact type and media type combinations. All implementations must provide
+  artifact type and media type combinations. All implementations must provide
   appropriate handlers for the used resources types to be interoperable.
 
 - **`value`** (required) *string*

--- a/doc/specification/extensionpoints/README.md
+++ b/doc/specification/extensionpoints/README.md
@@ -20,7 +20,7 @@ There are two different kinds of extension points:
 - [functional](functional.md) extension points offer the possibility to
   enrich an implementation of the Open Component Model by technology specific
   parts to support more technology environments, like storage backends for
-  the model information or artefacts described by the model.
+  the model information or artifacts described by the model.
 - [semantic](semantic.md) extension points offer the possibility to
   describe the semantic and/or structure of an element by arbitrary types not
   statically defined as part of the Open Component Model itself.

--- a/doc/specification/extensionpoints/functional.md
+++ b/doc/specification/extensionpoints/functional.md
@@ -4,13 +4,13 @@ The specification is based on 4 basic functional extension points:
 - The [storage backend technologies](../mapping/README.md) to use to store OCM
   elements (available
   mapping specifications can be found in [appendix A](../../appendix/A/README.md)).
-- [Access to artefact content](../elements/README.md#artefact-access) using
+- [Access to artifact content](../elements/README.md#artifact-access) using
   different storage technologies. This is described by types access
   specifications (types with available implementations can be found in
   [appendix B](../../appendix/B/README.md)).
 - [Digest](../elements/README.md#digests) calculation for dedicated content
   technologies requiring digests different from standard byte sequence digests
-  of artefact blobs (defined digest types can be found in
+  of artifact blobs (defined digest types can be found in
   [appendix C](../../appendix/C/README.md)).
 - Defined [signing](../elements/README.md#signing) extensions can be found in
   [appendix D](../../appendix/D/README.md)).

--- a/doc/specification/extensionpoints/semantic.md
+++ b/doc/specification/extensionpoints/semantic.md
@@ -1,11 +1,11 @@
 # Semantic Extension Points of the Open Component Model Specification
 
 The specification is based on two basic extension points for describing semantics
-of artefacts:
-- Formal artefact types describe the technical meaning of an artefact,
+of artifacts:
+- Formal artifact types describe the technical meaning of an artifact,
   independent of their technical representation in a blob format (centrally
   defined types are described in [appendix E](../../appendix/E/README.md)).
-- Dynamic attribution of artefacts with additional formal information not
+- Dynamic attribution of artifacts with additional formal information not
   directly described by elements of the Open Component Model is possible
   with labels. The meaning of dedicated label names is globally unique
   (centrally defined label names with their meaning are defined in

--- a/doc/specification/formats/README.md
+++ b/doc/specification/formats/README.md
@@ -7,7 +7,7 @@ for type-specific specification formats.
 
 2.4.1 [Types](types.md)
 - [Repository Types](types.md#repository-types)
-- [Artefact Types](types.md#artefact-types)
+- [Artifact Types](types.md#artifact-types)
 - [Access Method Types](types.md#access-method-types)
 - [Label Names](types.md#label-names)
 - [Normalization Types](types.md#normalization-types)
@@ -23,6 +23,6 @@ for type-specific specification formats.
 - [V3alpha1](compdesc/v3alpha1/README.md)
 
 2.4.4 [Normalization](normalization.md)
-- [Standard Artefact Normalization types](artefact_normalization.md)
+- [Standard Artifact Normalization types](artifact_normalization.md)
 - [Component Descriptor Normalization](componentdescriptor_normalization.md)
 

--- a/doc/specification/formats/artifact_normalization.md
+++ b/doc/specification/formats/artifact_normalization.md
@@ -1,15 +1,15 @@
-# Artefact Normalization
+# Artifact Normalization
 
-To be able to sign a component version, the content of described artefacts
-must be incorporated. Therefore, a digest for the artefact content must be
+To be able to sign a component version, the content of described artifacts
+must be incorporated. Therefore, a digest for the artifact content must be
 determined.
 
 By default, this digest is calculated based on the blob provided by the
-[access method](../elements/README.md#artefact-access)
-of an artefact. But there might be technology specific ways to uniquely identify
-the content for dedicated artefact types.
+[access method](../elements/README.md#artifact-access)
+of an artifact. But there might be technology specific ways to uniquely identify
+the content for dedicated artifact types.
 
-Therefore, together with the digest and its algorithm, an artefact normalization
+Therefore, together with the digest and its algorithm, an artifact normalization
 algorithm is kept in the [component descriptor](../elements/README.md#component-descriptor).
 
 ## Blob Representation Format for Resource Types
@@ -22,26 +22,26 @@ This explicitly includes access information, a formal description to describe a
 technical access path, which can be used to gain access to the real technical
 content. For the component model such content of resources is just seen as
 simple typed blobs. This enables to formally reference blobs in external
-environments, as long as the described [access method](../specification/elements/README.md#artefact-access)
+environments, as long as the described [access method](../specification/elements/README.md#artifact-access)
 is known to the consuming environment. The evaluation of an access specification
 always results in a simple blob representing the content of the described resource.
 This way basically all required blobs can be stored in any supported external blob store.
 
-An [access method](../../specification/elements/README.md#artefact-access) must
-always be able to return a blob representation for the accessed artefact.
-If there are native storage technologies for dedicated artefact types they
+An [access method](../../specification/elements/README.md#artifact-access) must
+always be able to return a blob representation for the accessed artifact.
+If there are native storage technologies for dedicated artifact types they
 must deliver such a blob, also.
 
 This basically means, whenever a new resource type is supported,
 corresponding blob formats must be defined for this type. Type-agnostic access types, like [`localBlob`](../B/localBlob.md) or [`ociBlob`](../B/ociBlob.md)
 just deal with those blobs, they never need to know anything about their internal
-format. But specific access methods, e.g. the [`ociArtecat`](../B/ociArtefact.md)
+format. But specific access methods, e.g. the [`ociArtecat`](../B/ociArtifact.md)
 method may provide dedicated blob formats.
 
-These blob formats may depend on the combination of artefact type and access type.
+These blob formats may depend on the combination of artifact type and access type.
 Therefore, a blob always has a *media type* specifying the technical format.
 
-For every artefact type the possible media types with their technical format
+For every artifact type the possible media types with their technical format
 specifications must be defined.
 
 When using the component repository to transport content from one repository the
@@ -52,22 +52,22 @@ access information stored along with the described resources may change over tim
 or from environment to environment. But all variants must describe the same
 technical content.
 
-If multiple media types are possible for blobs, the digest of the artefact content 
+If multiple media types are possible for blobs, the digest of the artifact content 
 must be immutable to avoid invalidating signatures. Therefore, in such a case, a
-dedicated artefact normalization algorithm has to be provided for such media types.
+dedicated artifact normalization algorithm has to be provided for such media types.
 
-Available artefact normalization types can be found in [appendix C](../../appendix/C/README.md#normalization-types).
+Available artifact normalization types can be found in [appendix C](../../appendix/C/README.md#normalization-types).
 
 ## Interaction of Local Blobs, Access Methods, Uploaders and Media Types
 
 The Open component model is desiged to support [transports](../../introduction/transports.md)
 of described content from one environment into another one.
 There are several mechanisms to support this:
-- the [access method](../elements/README.md#artefact-access) of an artefact
+- the [access method](../elements/README.md#artifact-access) of an artifact
   may change over time and from OCM repository to OCM repository used to store
   a component version.
 - the access method must define a procedure to provide a blob representation for
-  an artefact content.
+  an artifact content.
 - the model defines a [way to store content](../operations/README.md#mandatory-operations)
   along with the [component descriptor](../elements/README.md#component-descriptor) describing
   a [component version](../elements/README.md#component-versions).
@@ -78,24 +78,24 @@ involved model extensions.
 
 ### Access Methods
 
-A remote [access method](../elements/README.md#artefact-access) (access to an artefact
-storage outside the OCM repository) must return the artefact content as blob. 
+A remote [access method](../elements/README.md#artifact-access) (access to an artifact
+storage outside the OCM repository) must return the artifact content as blob. 
 
-By default, this blob is used to calculate the content digest for the artefact, 
+By default, this blob is used to calculate the content digest for the artifact, 
 therefore, this blob byte-stream must be deterministic. Multiple calls for the
 same content must return the identical blob.
 
 If this cannot be guaranteed, a blob digest handler for the media type of this
 blob format must be defined.
 
-For example. the [`ociArtefact`](../../appendix/B/ociArtefact.md) access method
-provides the content as artefact set
-blob, with a format based on the OCI artefact structure, which is defined by a dedicated
+For example. the [`ociArtifact`](../../appendix/B/ociArtifact.md) access method
+provides the content as artifact set
+blob, with a format based on the OCI artifact structure, which is defined by a dedicated
 media type. For this media type a digest handler is defined, which replaces the default
-blob digest by the manifest digest of the artefact. This way the digest is independent
-of the creatio of the archive blob containing the artefact.
+blob digest by the manifest digest of the artifact. This way the digest is independent
+of the creatio of the archive blob containing the artifact.
 
-Once the artefact content has been converted to a blob and stored as local blob
+Once the artifact content has been converted to a blob and stored as local blob
 in the component version (for example during a [transport](../../introduction/transports.md)
 step), this blob is by  default kept for further transport steps. This way,
 the digest calculation always provides the same result.
@@ -103,26 +103,26 @@ the digest calculation always provides the same result.
 ### Blob Uploaders
 
 An *Uploader* can be used as part of a transport process to automatically
-provide transported artefacts in technology specific local storage systems, again
+provide transported artifacts in technology specific local storage systems, again
 (e.g. OCI registries). The Open Component Model allows to change access locations
-of artefact content during a transport step, therefore such an automatic uploadeing
+of artifact content during a transport step, therefore such an automatic uploadeing
 with the modification of the access method is principally allows. But, in such
 scenarios dedicated rules must be obeyed to assure the integrity of digests and signatures.
 
-If a blob uploader is used to upload the artefact to a remote repository again, 
+If a blob uploader is used to upload the artifact to a remote repository again, 
 at the target side of a transport, the access method can potentially be changed
 to this new remote access accoding to the OCM specification.
 But this MUST guarantee the same digest calculation. The new access method must
 provide a blob again with a media type and digest handler combination, which
 provides the same digest.
 
-For example, storing an OCI artefact, delivered as local blob, in an OCI repository,
+For example, storing an OCI artifact, delivered as local blob, in an OCI repository,
 again, the manifest digest will be the same, because this is the identity of
-artefact according to the OCI specification. As a result, a new transformation
+artifact according to the OCI specification. As a result, a new transformation
 to a blob representation in combination with the digest handler will always
-provide the same artefact digest.
-Therefore, the access method can be switched again, from `localBlob` to `ociArtefact`
-regardless of the artefact type.
+provide the same artifact digest.
+Therefore, the access method can be switched again, from `localBlob` to `ociArtifact`
+regardless of the artifact type.
 
 If this is not possible, once a blob representation is chosen, it must be kept as
 it is. In such a case a blob uploader must preserve the local access method, even
@@ -133,6 +133,6 @@ This can be described in the component version, by adding this new remote access
 specification as part of the specification of the existing local one using
 the [`globalAccess` attribute](../../appendix/B/localBlob.md).
 
-The artefact digest is always calculated based on the local access, but tools 
+The artifact digest is always calculated based on the local access, but tools 
 may use the information provided by the global access for their purposes to
-use technology native ways to access the artefact.
+use technology native ways to access the artifact.

--- a/doc/specification/formats/compdesc/v2/README.md
+++ b/doc/specification/formats/compdesc/v2/README.md
@@ -21,7 +21,7 @@ A *Component Descriptor* document consists of two top level elements: *meta*, *c
 |  | Description |
 | --- | --- |
 | meta | Contains the schema version of the *Component Descriptor* specification. This document defines schema version *v2*. |
-| component | Definition of the artefacts which belong to the component version. |
+| component | Definition of the artifacts which belong to the component version. |
 
 Example:
 

--- a/doc/specification/formats/componentdescriptor_normalization.md
+++ b/doc/specification/formats/componentdescriptor_normalization.md
@@ -4,8 +4,8 @@ The [component descriptor](../formats/compdesc/README.md) is used to describe
 a [component version](model.md#component-versions). It contains several kinds
 of information:
 - volatile label settings, which might be changeable.
-- artefact access information, which might be changed during transport steps.
-- static information describing the features and artefacts of a component
+- artifact access information, which might be changed during transport steps.
+- static information describing the features and artifacts of a component
   version.
 
 For signing a digest of the component descriptor needs to be generated.

--- a/doc/specification/formats/formats.md
+++ b/doc/specification/formats/formats.md
@@ -37,20 +37,20 @@ can be found in [appendix A](../../appendix/A/README.md)
 ## Access Specifications
 
 Access specifications are used to describe the technical access path
-of the content of [artefacts](../elements/README.md#artefacts) described by a
+of the content of [artifacts](../elements/README.md#artifacts) described by a
 [component version](../elements/README.md#component-versions).
 Every access specification has a formal type and type specific attributes.
 The type uniquely specifies the technical procedure how to use the
 attributes and the [repository context](../elements/README.md#repository-contexts) of
 the component descriptor containing the access specification
-to retrieve the content of the artefact.
+to retrieve the content of the artifact.
 
-There are basically two ways an artefact blob can be stored:
-- `external` access methods allow referring to artefacts in any other
+There are basically two ways an artifact blob can be stored:
+- `external` access methods allow referring to artifacts in any other
   technical repository as long as the access type is supported by the
   used tool set.
 - `internal` access methods ([`localBlob`](../../appendix/B/localBlob.md)).
-  are used to store an artefact together with the component descriptor in an
+  are used to store an artifact together with the component descriptor in an
   OCM repository. These methods must be supported by all OCM repository
   implementations.
 

--- a/doc/specification/formats/normalization.md
+++ b/doc/specification/formats/normalization.md
@@ -1,22 +1,22 @@
 # 2.4.4 Normalization
 
 To be able to sign a [component version](../../specification/elements/README.md#component-versions), the metadata of a component version and the
-content of described artefacts must be incorporated.
+content of described artifacts must be incorporated.
 
-The metadata of a component version is described by a [component-descriptor](../../specification/elements/README.md#component-descriptor). It contains volatile information, also, e.g. the artefact access specification, which might change during [transports](../../introduction/transports.md).
+The metadata of a component version is described by a [component-descriptor](../../specification/elements/README.md#component-descriptor). It contains volatile information, also, e.g. the artifact access specification, which might change during [transports](../../introduction/transports.md).
 Therefore, to calculate a digest, the component descriptor has to be transformed
 to an immutable technical reprsentation containing only signature relevant information. THis process is called [*component descriptor normalization*](componentdescriptor_normalization.md).
 
-To cover the content of the artefacts described by a component version, a digest
-for the artefact content has to be calculated, also, and incorporated into the
+To cover the content of the artifacts described by a component version, a digest
+for the artifact content has to be calculated, also, and incorporated into the
 immutable information of the component descriptor.
 
 By default, this digest is calculated based on the blob provided by the
-[access method](../elements/README.md#artefact-access)
-of an artefact. But there might be technology specific ways to uniquely identify
-the content for dedicated artefact types, which might depend on the chosen blob media type.
+[access method](../elements/README.md#artifact-access)
+of an artifact. But there might be technology specific ways to uniquely identify
+the content for dedicated artifact types, which might depend on the chosen blob media type.
 
-Therefore, together with the digest and its algorithm, an artefact normalization
+Therefore, together with the digest and its algorithm, an artifact normalization
 algorithm is kept in the [component descriptor](../elements/README.md#component-descriptor).
-This process is called [*artefact blob normalization]*(artefact_normalization.md)
+This process is called [*artifact blob normalization]*(artifact_normalization.md)
 

--- a/doc/specification/formats/types.md
+++ b/doc/specification/formats/types.md
@@ -14,14 +14,14 @@ of the described element.
 
 - [Access Method Types](#access-method-types)
 
-  [Access methods](../elements/README.md#artefact-access) describe dedicated
+  [Access methods](../elements/README.md#artifact-access) describe dedicated
   technical ways how to access the blob
-  content of an [artefact](../elements/README.md#artefacts) described by an
+  content of an [artifact](../elements/README.md#artifacts) described by an
   [OCM component descriptor](../formats/compdesc/README.md). It is evaluated in
   the storage context used to read the component descriptor containing the
   access method description.
 
-- [Artefact Types](#artefact-types)
+- [Artifact Types](#artifact-types)
 
   The OCM component descriptor describes a set of resources, their type and
   meaning with attached meta and access information.
@@ -34,7 +34,7 @@ of the described element.
 
 - [Normalization Types](#normalization-types)
 
-  To calculate signatures, digests must be calculated for artefact content.
+  To calculate signatures, digests must be calculated for artifact content.
   
 ## Repository Types
 
@@ -89,15 +89,15 @@ There are two kinds of types:
 
 ## Access Method Types
 
-[Access methods](../elements/README.md#artefact-access) describe (and finally
+[Access methods](../elements/README.md#artifact-access) describe (and finally
 implement) dedicated technical ways how to
-access the blob content of an [artefact](../elements/README.md#artefacts)
+access the blob content of an [artifact](../elements/README.md#artifacts)
 described by an [OCM component descriptor](../elements/README.md#component-descriptor).
 
 They are an integral part of the [Open Component Model](../../../README.md). They always
 provide the link between a component version stored in some repository context,
 and the technical access of the described resources applicable for this
-context. Therefore, the access specification as well as the method of an artefact
+context. Therefore, the access specification as well as the method of an artifact
 may change when component versions are transported among repository contexts.
 
 In a dedicated context all used access methods must be known by the used tool
@@ -108,7 +108,7 @@ their implementations to support own local environments.
 Because of this extensibility, the names of access methods must be globally
 unique.
 
-Like for [artefact types](#artefact-types), there are two flavors
+Like for [artifact types](#artifact-types), there are two flavors
 of method names:
 
 - centrally provided access methods
@@ -118,7 +118,7 @@ of method names:
   access methods can be use across local organizational extension.
 
   These types use flat names following a camel case scheme with
-  the first character in lower case (for example `ociArtefact`).
+  the first character in lower case (for example `ociArtifact`).
 
   Their format is described by the following regexp:
 
@@ -167,15 +167,15 @@ v[0-9]+([a-z][a-z0-9]*)?
 ```
 
 Examples:
-- `ociArtefact/v1`
+- `ociArtifact/v1`
 - `myprotocol.acme.org/v1alpha1`
 
 If no version is specified, implicitly the version `v1` is assumed.
 
-The access method type is part of the access specification of an artefact
+The access method type is part of the access specification of an artifact
 in the component descriptor. The access method type may define
 additional specification attributes required to finally identify the
-concrete access path to the artefact blob.
+concrete access path to the artifact blob.
 
 For example, the access method `ociBlob` requires the OCI repository reference
 and the blob digest to be able to access the blob.
@@ -183,40 +183,40 @@ and the blob digest to be able to access the blob.
 Centrally defined access methods with their specification versions
 can be found in [appendix B](../../appendix/B/README.md).
 
-## Artefact Types
+## Artifact Types
 
 The [OCM component version](../elements/README.md#component-versions) describes
-a set of [artefacts](../elements/README.md#artefacts), their type and
+a set of [artifacts](../elements/README.md#artifacts), their type and
 meaning with attached meta, and access information.
 
-The formal type of an artefact uniquely specifies the
-logical interpretation of an artefact, its kind, independent of its
+The formal type of an artifact uniquely specifies the
+logical interpretation of an artifact, its kind, independent of its
 concrete technical representation.
 
 If there are different possible technical representation the
-[access method](../elements/README.md#artefact-access)
+[access method](../elements/README.md#artifact-access)
 returns the concrete format given by a media type used for the returned blob.
 
 For example, a helm chart (type `helmChart`) can be represented as
-OCI artefact or helm chart archive. Nevertheless, the technical meaning is
+OCI artifact or helm chart archive. Nevertheless, the technical meaning is
 to be a helm chart, even if represented as OCI image. The type `ociImage`
 describes an object that can be used as container image. So, although the
 technical representation might in both cases be an OCI image manifest, its
 semantics and use case is completely different. This is expressed
-by the chosen type of the artefact, which focuses on the semantics.
+by the chosen type of the artifact, which focuses on the semantics.
 
-The kind and logical interpretation of a technical artefact is basically
+The kind and logical interpretation of a technical artifact is basically
 encoded into a dedicated simple string.
-Because the interpretation of an artefact must be the same, independent
+Because the interpretation of an artifact must be the same, independent
 of the provisioning and consumption environment of a component version,
-the artefact type must be globally unique.
+the artifact type must be globally unique.
 The OCM defines a dedicated naming scheme to guarantee this uniqueness.
 
 There are two kinds of types:
 - centrally defined type names managed by the OCM organization
 
   These types use flat names following a camel case scheme with
-  the first character in lower case (for example `ociArtefact`).
+  the first character in lower case (for example `ociArtifact`).
 
   Their format is described by the following regexp:
 
@@ -269,7 +269,7 @@ the set of labels must be extensible.
 Because of this extensibility, the names of labels must be globally
 unique, also.
 
-Like for [artefact types](#artefact-types) there are two flavors
+Like for [artifact types](#artifact-types) there are two flavors
 of label names:
 
 - labels with a predefined meaning for the component model itself.
@@ -323,21 +323,21 @@ can be found in [appendix F](../../appendix/F/README.md).
 
 ## Normalization Types
 
-To be able to sign a component version, the content of described artefacts
-must be incorporated. Therefore, a digest for the artefact content must be
+To be able to sign a component version, the content of described artifacts
+must be incorporated. Therefore, a digest for the artifact content must be
 determined.
 
 By default, this digest is calculated based on the blob provided by the
-[access method](../elements/README.md#artefact-access)
-of an artefact. But there might be technology specific ways to uniquely identify
-the content for dedicated artefact types.
+[access method](../elements/README.md#artifact-access)
+of an artifact. But there might be technology specific ways to uniquely identify
+the content for dedicated artifact types.
 
-Therefore, together with the digest and its algorithm, an artefact normalization
+Therefore, together with the digest and its algorithm, an artifact normalization
 algorithm is kept in the [component descriptor](../elements/README.md#component-descriptor).
 
 The same problem appears for the component descriptor. It contains signature
 relevant information and volatile information (e.g. the
-[access specification](../elements/README.md#artefact-access)). Therefore, there
+[access specification](../elements/README.md#artifact-access)). Therefore, there
 is a [normalization for component descriptors](componentdescriptor_normalization.md), also.
 
 Normalization algorithm types may be versioned and SHOULD match the following regexp
@@ -346,7 +346,7 @@ Normalization algorithm types may be versioned and SHOULD match the following re
 [a-z][a-zA-Z0-9]*/v[0-9]+([a-z][a-z0-9]*)
 ```
 
-For example: `ociArtefactDigest/v1` or `jsonNormalisationV2`
+For example: `ociArtifactDigest/v1` or `jsonNormalisationV2`
 
-There are standardized normalization types for [artefacts](artefact_normalization.md)
+There are standardized normalization types for [artifacts](artifact_normalization.md)
 and [component descriptors](componentdescriptor_normalization.md).

--- a/doc/specification/operations/README.md
+++ b/doc/specification/operations/README.md
@@ -7,11 +7,11 @@ OCI registry or an S3 blob store).
 These operations build the first extension point of OCM, which allows to 
 map the OCM functionality onto any blobstore-like storage system.
 
-A second extension point is the [access to artefacts](../elements/README.md#artefact-access)
+A second extension point is the [access to artifacts](../elements/README.md#artifact-access)
 described by a [component version](../elements/README.md#component-versions).
 Such access is described by an [access specification](../formats/formats.md#access-specifications)
 which is specific for a dedicated access method, whose implementation handles the
-technical access to the artefact content. Implementations for those methods must
+technical access to the artifact content. Implementations for those methods must
 implement some operations on the access specifications.
 
 The concrete incarnation of those repository and access method operations depend
@@ -66,17 +66,17 @@ The following operations are mandatory:
   the blob, again (together with the component version identity).
 
   Additionally, a dedicated media type can be used to decide how to internally
-  represent the artefact content.
+  represent the artifact content.
 
   Optionally, the operation may decide to store the blob in dedicated ways according
   to its media type. For example, an OCI based implementation can represent
-  blobs containing an OCI artefact as regular, globally addressable object.
+  blobs containing an OCI artifact as regular, globally addressable object.
 
   A type-specific optional *ReferenceHint* can be passed to guide the
   operation for generating an identity, if it decided to make the object
   externally visible.
 
-  If this is the case, an external [access specification](../elements/README.md#artefact-access)
+  If this is the case, an external [access specification](../elements/README.md#artifact-access)
   has to be returned. At least a blob identity or an external access specification
   has to be returned for not successful executions.
 
@@ -127,7 +127,7 @@ for the denoted blob is required.
 
 - **`<method>.GetMediaType(RepositoryContext, ComponentVersion, AccessSpecification) (string, error)`**
 
-  Provide the media type of the described artefact. It might explicitly be stored
+  Provide the media type of the described artifact. It might explicitly be stored
   as part of the access specification, or implicitly provided by the access method.
 
 - **`<method>.GetStream(RepositoryContext, ComponentVersion, AccessSpecification) (Byte Stream, error)`**

--- a/example/transfer-components-fanced-network.md
+++ b/example/transfer-components-fanced-network.md
@@ -72,7 +72,7 @@ Sign:
 ❯ ocm sign componentversions ocm-ta-flow-ca \
     -s ww-ocm-sig -K private-key.pem -k public-key.pem
 applying to version "ghcr.io/sap/ocm-ta-flow:0.0.1"...
-  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtefactDigest/v1]
+  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtifactDigest/v1]
 successfully signed ghcr.io/sap/ocm-ta-flow:0.0.1 (digest sha256:a990e44fc567e8668796a1ef343922ce88febb1fc6742518cd0bd12b89faa316)
 ```
 
@@ -106,7 +106,7 @@ After that we have this directory structure:
 
 ❯ tar ztf ocm-ta-flow-ca-ta.tar.gz | tree --fromfile .
 .
-├── artefact-index.json
+├── artifact-index.json
 └── blobs
     ├── sha256.46f15984e3f2c7d779199e2e649d24d9ad8357404a6195ca73733097c622b5eb
     ├── sha256.f338df813e8b19652565a4a31407fae7a5a52fb162a6e867c2caab53d77c02cb
@@ -131,7 +131,7 @@ We can verify the content:
 
 ```bash
 ❯ tar ztf hello-world.tar.gz
-artefact-descriptor.json
+artifact-descriptor.json
 blobs
 blobs/sha256.2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488
 blobs/sha256.5305f40ab0c9c75856e5ffe193f47253e53696305f0da5ec44dacadec342328d
@@ -139,12 +139,12 @@ blobs/sha256.92360c1eaf0032a860dddb1e3cdc16b27bdfec509c23de434dbe53d3d35bed9d
 blobs/sha256.df9b9388f04ad6279a7410b85cedfdcb2208c0a003da7ab5613af71079148139
 ```
 
-#### Add artefact to the component transfer archive
+#### Add artifact to the component transfer archive
 
 ```bash
-❯ ocm oci artefacts transfer ./hello-world.tar.gz ./ocm-ta-flow-ca-ta.tar.gz
+❯ ocm oci artifacts transfer ./hello-world.tar.gz ./ocm-ta-flow-ca-ta.tar.gz
 copying :1.0.7 to :1.0.7...
-copied 1 from 1 artefact(s)
+copied 1 from 1 artifact(s)
 ```
 
 #### Advanced SHA256 check
@@ -168,7 +168,7 @@ ok: sha256.df9b9388f04ad6279a7410b85cedfdcb2208c0a003da7ab5613af71079148139
 
 ### Transfer
 
-Once the artefact is copied, we can use OCM to verify its signature, and extract
+Once the artifact is copied, we can use OCM to verify its signature, and extract
 it.
 
 #### Verify
@@ -185,6 +185,6 @@ We can verify the signing key with:
 ```bash
 ❯ ocm verify componentversion --signature ww-ocm-sig --public-key=public-key.pem  ./ocm-ta-flow-ca-ta.tar.gz
 applying to version "ghcr.io/sap/ocm-ta-flow:0.0.1"...
-  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtefactDigest/v1]
+  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtifactDigest/v1]
 successfully verified ghcr.io/sap/ocm-ta-flow:0.0.1 (digest sha256:a990e44fc567e8668796a1ef343922ce88febb1fc6742518cd0bd12b89faa316)
 ```

--- a/example/upload-component-to-oci-registry.md
+++ b/example/upload-component-to-oci-registry.md
@@ -118,7 +118,7 @@ We can sign before we upload the component, but we can sign it after upload too.
 ```bash
 ❯ ocm sign componentversions -s ww-ocm-sig -K private-key.pem -k public-key.pem ./hello-world-component
 applying to version "github.com/yitsushi/hello-world:1.0.7"...
-  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtefactDigest/v1]
+  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtifactDigest/v1]
 successfully signed github.com/yitsushi/hello-world:1.0.7 (digest sha256:0452632bf29b38bc8887387019f87d459a9e88c517b744f9e5ad807bc672c479)
 ```
 
@@ -136,7 +136,7 @@ component:
       type: ociRegistry
     digest:
       hashAlgorithm: sha256
-      normalisationAlgorithm: ociArtefactDigest/v1
+      normalisationAlgorithm: ociArtifactDigest/v1
       value: 2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488
     name: server
     relation: external
@@ -199,7 +199,7 @@ pushing 1.0.7
     --repo OCIRepository::ghcr.io/sap \
     github.com/yitsushi/hello-world:1.0.7
 applying to version "github.com/yitsushi/hello-world:1.0.7"...
-  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtefactDigest/v1]
+  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtifactDigest/v1]
 successfully signed github.com/yitsushi/hello-world:1.0.7 (digest sha256:0452632bf29b38bc8887387019f87d459a9e88c517b744f9e5ad807bc672c479)
 ```
 
@@ -212,7 +212,7 @@ successfully signed github.com/yitsushi/hello-world:1.0.7 (digest sha256:0452632
     --repo OCIRepository::ghcr.io/sap \
     github.com/yitsushi/hello-world:1.0.7
 applying to version "github.com/yitsushi/hello-world:1.0.7"...
-  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtefactDigest/v1]
+  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtifactDigest/v1]
 successfully verified github.com/yitsushi/hello-world:1.0.7 (digest sha256:0452632bf29b38bc8887387019f87d459a9e88c517b744f9e5ad807bc672c479)
 ```
 
@@ -231,7 +231,7 @@ transferring version "github.com/yitsushi/hello-world:1.0.7"...
 
 ```bash
 ❯ tar ztf ctf.tgz
-artefact-index.json
+artifact-index.json
 blobs
 blobs/sha256.2eae2829e60c287ac2dabd3daed4fed9a45a021ebe0c0ff29e9db20b160f3b53
 blobs/sha256.4e972b297e47151dacd2582b9acaf9a94cda0203fe148e81d4e5f59cd7b8710b
@@ -245,6 +245,6 @@ blobs/sha256.d3418290d87f05f52c1801557c00d3e43eb0bcf1bb960331b3967c639541582f
     --signature ww-ocm-sig --public-key=public-key.pem \
     ./ctf.tgz
 applying to version "github.com/yitsushi/hello-world:1.0.7"...
-  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtefactDigest/v1]
+  resource 0:  "name"="server": digest sha256:2f97e43aea52dede928ccd2e1bcd75325b157bd2d5e893e3cd179e6eb5de1488[ociArtifactDigest/v1]
 successfully verified github.com/yitsushi/hello-world:1.0.7 (digest sha256:0452632bf29b38bc8887387019f87d459a9e88c517b744f9e5ad807bc672c479)
 ```


### PR DESCRIPTION
```bash
rg -l artefact | xargs -I {} sed -i 's/artefact/artifact/g' {}
rg -l Artefact | xargs -I {} sed -i 's/Artefact/Artifact/g' {}

find . -name '*artefact*' | grep -v '.git' | xargs -I {} rename artefact artifact {}
```

Related to: https://github.com/open-component-model/ocm/issues/183