### PR TITLE
Fix broken links for `Component Descriptor` and `Component Repository`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ To use a backend storage technology as an OCM repository it is necessary to prov
 
 1 [Introduction](doc/introduction/README.md)
 
-1.1 [Component Descriptor](doc/introduction/01_component_descriptor.md)<br>
-1.2 [Component Repository](doc/introduction/02_component_repository.md)<br>
+1.1 [Component Descriptor](doc/introduction/component_versions.md)<br>
+1.2 [Component Repository](doc/introduction/component_repository.md)<br>
 
 2 [OCM Specification](doc/specification/README.md)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Links for `Component Descriptor` and `Component Repository` were broken. I adjusted them to link the same files as in [introduction](https://github.com/open-component-model/ocm-spec/blob/main/doc/introduction/README.md).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
