### PR TITLE
Add documentation for wget access type

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The following chapters provide a formal description of the format to describe so
 
 ## Central OCM project web page
 
-Check out the main project [web page](https://ocm.software) to find out more about OCM. It is your central entry point to all kinds of ocm related [docs and guides](https://ocm.software/docs/overview/context/), this [spec](https://ocm.software/spec/) and all project-related [github repositories](https://github.com/open-component-model). It also offers a [Getting Started](https://ocm.software/docs/guides/getting-started-with-ocm) to quickly make your hands dirty with ocm, its toolset and concepts :-)
+Check out the main project [web page](https://ocm.software) to find out more about OCM. It is your central entry point to all kinds of ocm related [docs and guides](https://ocm.software/docs/overview/context/), this [spec](https://ocm.software/docs/overview/specification/) and all project-related [github repositories](https://github.com/open-component-model). It also offers a [Getting Started](https://ocm.software/docs/getting-started/first-steps-with-ocm/) to quickly make your hands dirty with ocm, its toolset and concepts :-)
 
 ## Contributing
 

--- a/doc/04-extensions/02-access-types/README.md
+++ b/doc/04-extensions/02-access-types/README.md
@@ -8,8 +8,8 @@ required to identify the blob and its location.
 
 The following access method types are centrally defined:
 
-| TYPE NAME | DESCRIPTION |
-|-----------|-------------|
+| TYPE NAME                       | DESCRIPTION                                         |
+|---------------------------------|-----------------------------------------------------|
 | [`localBlob`](localblob.md)     | an artifact stored along with the component version |
 | [`ociArtifact`](ociartifact.md) | an artifact in a repository of an OCI registry      |
 | [`ociBlob`](ociblob.md)         | a blob in a repository of an OCI registry           |
@@ -17,3 +17,5 @@ The following access method types are centrally defined:
 | [`gitHub`](github.md)           | a commit in a GitHub-based Git repository           |
 | [`s3`](s3.md)                   | a blob stored in an AWS S3 bucket                   |
 | [`npm`](npm.md)                 | a NodeJS package stored in an NPM repository        |
+| [`wget`](wget.md)               | a blob stored on an HTTP server                     |
+

--- a/doc/04-extensions/02-access-types/README.md
+++ b/doc/04-extensions/02-access-types/README.md
@@ -18,4 +18,3 @@ The following access method types are centrally defined:
 | [`s3`](s3.md)                   | a blob stored in an AWS S3 bucket                   |
 | [`npm`](npm.md)                 | a NodeJS package stored in an NPM repository        |
 | [`wget`](wget.md)               | a blob stored on an HTTP server                     |
-

--- a/doc/04-extensions/02-access-types/wget.md
+++ b/doc/04-extensions/02-access-types/wget.md
@@ -1,0 +1,51 @@
+# wget — Blob hosted on an HTTP server
+
+## Synopsis
+
+```text
+type: wget[/VERSION]
+[ATTRIBUTES]
+```
+
+## Description
+
+Access to a blob stored on an HTTP server.
+
+## Supported Media Types
+
+The provided media type is taken from the specification attribute `mediaType`.
+
+## Specification Version
+
+The following versions are supported
+
+### v1
+
+Attributes:
+
+- **`url`** *string*
+
+  The url describes from which http server endpoint the resource is downloaded
+
+- **`mediaType`** (optional) *string*
+
+  The media type of the blob used to store the resource. It may add
+  format information like `+tar` or `+gzip`.
+
+- **`header`** (optional) *map[string][]string*
+
+  The header describes the http headers to be set in the http request to the server.
+
+- **`verb`** (optional) *string*
+
+  The verb describes the http verb (also known as http request method) for the http
+  request.
+
+- **`body`** (optional) *[]byte*
+
+  The body describes the http body to be included in the request.
+
+- **`noredirect`** (optional) *bool*
+
+  The noredirect describes whether http redirects should be disabled.
+

--- a/doc/04-extensions/02-access-types/wget.md
+++ b/doc/04-extensions/02-access-types/wget.md
@@ -32,7 +32,7 @@ Attributes:
   The media type of the blob used to store the resource. It may add
   format information like `+tar` or `+gzip`.
 
-- **`header`** (optional) *map[string][]string*
+- **`header`** (optional) *map\[string\][]string*
 
   The header describes the http headers to be set in the http request to the server.
 
@@ -48,4 +48,3 @@ Attributes:
 - **`noredirect`** (optional) *bool*
 
   The noredirect describes whether http redirects should be disabled.
-

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -58,7 +58,7 @@ the artifact blob.
 an abstract entity describing a dedicated usage context or
 meaning for a provided piece of software.
 
-### [Component Constructor](https://github.com/open-component-model/ocm-website/blob/main/content/en/docs/guides/getting-started-with-ocm.md#all-in-one)<a id="compconst"/>
+### [Component Constructor](https://ocm.software/docs/getting-started/first-steps-with-ocm/#all-in-one)<a id="compconst"/>
 
 a file that acts as input for the OCM CLI to construct one or multiple component version(s).
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The ocm tooling introduced the wget access method [here](https://github.com/open-component-model/ocm/pull/630). This adds documentation to the corresponding spec section.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE

```
