### PR TITLE
chore(docs): add floating tag spec updates

### DIFF
--- a/doc/03-persistence/01-operations.md
+++ b/doc/03-persistence/01-operations.md
@@ -89,6 +89,26 @@ Optional operations might be:
   It should not only return component identities, that are direct children,
   but traverse the complete subtree.
 
+##### Version Alias Operations
+
+Storage backends **MAY** expose an extended interface
+for managing symbolic aliases (floating tags) that resolve to concrete component versions.
+
+An alias is a mutable, human-readable name (e.g., `latest`, `stable`, `production`)
+that resolves to exactly one component version at any point in time. Alias names
+**MUST NOT** be valid OCM version strings.
+
+- **`AddComponentVersionAlias(ComponentId, VersionOrAliasName, AliasName) error`**
+
+  Attach a symbolic alias to an existing component version (or to another alias, enabling
+  alias chains). `AliasName` **MUST NOT** be a valid OCM version string. If the alias
+  already exists it is updated to point to the new target.
+
+- **`RemoveComponentVersionAlias(ComponentId, AliasName) error`**
+
+  Remove an alias. Only the alias pointer is removed; the underlying component version
+  and its content are not affected. `AliasName` **MUST NOT** be a valid OCM version string.
+
 ### Access Method Operations
 
 There must be an implementation for all supported external access methods

--- a/doc/03-persistence/01-operations.md
+++ b/doc/03-persistence/01-operations.md
@@ -100,9 +100,9 @@ that resolves to exactly one component version at any point in time. Alias names
 
 - **`AddComponentVersionAlias(ComponentId, VersionOrAliasName, AliasName) error`**
 
-  Attach a symbolic alias to an existing component version (or to another alias, enabling
-  alias chains). `AliasName` **MUST NOT** be a valid OCM version string. If the alias
-  already exists it is updated to point to the new target.
+  Attach a symbolic alias to an existing component version. `VersionOrAliasName` is either
+  a version or an existing alias; `AliasName` **MUST NOT** be a valid OCM version string.
+  If the alias already exists it is updated to point to the new target.
 
 - **`RemoveComponentVersionAlias(ComponentId, AliasName) error`**
 

--- a/doc/04-extensions/03-storage-backends/ctf.md
+++ b/doc/04-extensions/03-storage-backends/ctf.md
@@ -72,6 +72,7 @@ The alias entry is removed from `artifact-index.json`. Only the index entry is r
 manifest blob and all referenced content blobs remain in the CTF archive.
 
 Implementations **MUST** return an error if:
+
 * `AliasName` is a valid OCM version string.
 * No entry with the given tag exists in the repository.
 

--- a/doc/04-extensions/03-storage-backends/ctf.md
+++ b/doc/04-extensions/03-storage-backends/ctf.md
@@ -55,6 +55,26 @@ This format uses the `OCIRegistry` element mapping to map OCM elements to OCI el
 This format supports no dedicated blob mappings.
 Local blobs are always stored as blobs.
 
+## Alias Management Operations
+
+CTF archives support the optional version alias operations defined in
+[Version Alias Operations](../../../doc/03-persistence/01-operations.md#version-alias-operations).
+
+**`AddComponentVersionAlias`**
+
+The alias is recorded in `artifact-index.json` as a tag pointing to the same digest as the
+target component version. If the tag already exists it **MUST** be updated to point to the
+new digest. `AliasName` **MUST NOT** be a valid OCM version string.
+
+**`RemoveComponentVersionAlias`**
+
+The alias entry is removed from `artifact-index.json`. Only the index entry is removed; the
+manifest blob and all referenced content blobs remain in the CTF archive.
+
+Implementations **MUST** return an error if:
+* `AliasName` is a valid OCM version string.
+* No entry with the given tag exists in the repository.
+
 ## Examples
 
 ```text

--- a/doc/04-extensions/03-storage-backends/ctf.md
+++ b/doc/04-extensions/03-storage-backends/ctf.md
@@ -59,7 +59,12 @@ Local blobs are always stored as blobs.
 
 CTF archives **MAY** implement the optional version alias operations defined in
 [Version Alias Operations](../../../doc/03-persistence/01-operations.md#version-alias-operations).
-The following describes how each operation maps onto the CTF artifact index.
+Alias resolution uses the existing
+[`GetComponentVersion`](../../../doc/03-persistence/01-operations.md#repository-operations)
+operation — an alias name is passed where a version is expected and resolves via tag lookup
+in `artifact-index.json`.
+
+The following describes how each write operation maps onto the CTF artifact index.
 
 **`AddComponentVersionAlias`**
 

--- a/doc/04-extensions/03-storage-backends/ctf.md
+++ b/doc/04-extensions/03-storage-backends/ctf.md
@@ -57,13 +57,14 @@ Local blobs are always stored as blobs.
 
 ## Alias Management Operations
 
-CTF archives support the optional version alias operations defined in
+CTF archives **MAY** implement the optional version alias operations defined in
 [Version Alias Operations](../../../doc/03-persistence/01-operations.md#version-alias-operations).
+The following describes how each operation maps onto the CTF artifact index.
 
 **`AddComponentVersionAlias`**
 
-The alias is recorded in `artifact-index.json` as a tag pointing to the same digest as the
-target component version. If the tag already exists it **MUST** be updated to point to the
+The alias is recorded in `artifact-index.json` as a tag pointing to the same digest as
+`VersionOrAliasName` (a version or existing alias). If the tag already exists it **MUST** be updated to point to the
 new digest. `AliasName` **MUST NOT** be a valid OCM version string.
 
 **`RemoveComponentVersionAlias`**

--- a/doc/04-extensions/03-storage-backends/oci.md
+++ b/doc/04-extensions/03-storage-backends/oci.md
@@ -56,6 +56,7 @@ The specification also introduces a Component Index artifact used for referrer-b
     * [12.1 Version Aliasing](#121-version-aliasing)
       * [12.1.1 Resolution Rules](#1211-resolution-rules)
       * [12.1.2 Interaction with Component Version Processing](#1212-interaction-with-component-version-processing)
+      * [12.1.3 Alias Management Operations](#1213-alias-management-operations)
   * [13. Compatibility Requirements](#13-compatibility-requirements)
   * [Examples (Informative)](#examples-informative)
     * [Simple Examples](#simple-examples)
@@ -854,6 +855,46 @@ Clients **SHOULD** reveal both:
 * the resolved version,
 
 to ensure transparency and debuggability.
+
+#### 12.1.3 Alias Management Operations
+
+This section defines how the optional version alias operations from
+[Version Alias Operations](../../../doc/03-persistence/01-operations.md#version-alias-operations)
+are implemented against an OCI registry.
+
+**`AddComponentVersionAlias`**
+
+Implementations **MUST** resolve `VersionOrAliasName` as an OCI tag or digest in the
+component's repository, validate that the resolved descriptor represents a valid OCM
+component version, and then push the alias as an OCI tag pointing to that descriptor
+using the [OCI Distribution Specification manifest push](https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pushing-manifests)
+mechanism.
+
+`AliasName` **MUST** be rejected if it is a valid OCM version string.
+
+Because `VersionOrAliasName` **MAY** itself be a non-version alias, implementations
+**MUST** accept non-semver names there and resolve them to their underlying descriptor
+before tagging. This enables alias chains: e.g., pointing `edge` to wherever `latest`
+currently resolves.
+
+After a successful push the alias tag in the registry **MUST** resolve to the descriptor
+identified by `VersionOrAliasName`. If the tag already pointed elsewhere it is overwritten.
+
+**`RemoveComponentVersionAlias`**
+
+Implementations **MUST** remove the alias tag from the component's OCI repository without
+deleting the underlying manifest or blobs, using the
+[OCI Distribution Specification tag deletion](https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#deleting-tags)
+mechanism.
+
+Implementations **MUST** return an error if:
+* `AliasName` is a valid OCM version string.
+* The alias tag does not exist.
+* The resolved descriptor is not a valid OCM component version.
+
+Implementations **SHOULD** propagate registry-level errors that indicate tag deletion is
+not supported (e.g., a `405 Method Not Allowed` response) as a distinct error to allow
+callers to handle the capability gap gracefully.
 
 ## 13. Compatibility Requirements
 

--- a/doc/04-extensions/03-storage-backends/oci.md
+++ b/doc/04-extensions/03-storage-backends/oci.md
@@ -816,6 +816,11 @@ Aliases that rely on SemVer ordering:
 
 Aliases whose semantics do not rely on SemVer (e.g., `edge` → “most recently published”) **MAY** be supported, but clients **MUST** specify their selection criteria.
 
+Alias resolution uses the existing
+[`GetComponentVersion`](../../../doc/03-persistence/01-operations.md#repository-operations)
+operation — an alias name is passed where a version is expected and resolves via standard
+OCI tag lookup.
+
 #### 12.1.1 Resolution Rules
 
 Alias resolution **MUST** produce exactly one concrete version tag.
@@ -857,10 +862,6 @@ Clients **SHOULD** reveal both:
 to ensure transparency and debuggability.
 
 #### 12.1.3 Alias Management Operations
-
-This section defines how the optional version alias operations from
-[Version Alias Operations](../../../doc/03-persistence/01-operations.md#version-alias-operations)
-are implemented against an OCI registry.
 
 **`AddComponentVersionAlias`**
 

--- a/doc/04-extensions/03-storage-backends/oci.md
+++ b/doc/04-extensions/03-storage-backends/oci.md
@@ -888,6 +888,7 @@ deleting the underlying manifest or blobs, using the
 mechanism.
 
 Implementations **MUST** return an error if:
+
 * `AliasName` is a valid OCM version string.
 * The alias tag does not exist.
 * The resolved descriptor is not a valid OCM component version.

--- a/doc/04-extensions/03-storage-backends/oci.md
+++ b/doc/04-extensions/03-storage-backends/oci.md
@@ -864,21 +864,16 @@ are implemented against an OCI registry.
 
 **`AddComponentVersionAlias`**
 
-Implementations **MUST** resolve `VersionOrAliasName` as an OCI tag or digest in the
-component's repository, validate that the resolved descriptor represents a valid OCM
-component version, and then push the alias as an OCI tag pointing to that descriptor
-using the [OCI Distribution Specification manifest push](https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pushing-manifests)
+Implementations **MUST** resolve `VersionOrAliasName` (a version or existing alias) as an OCI tag in the component's
+repository, validate that the resolved descriptor represents a valid OCM component version,
+and then push the alias as an OCI tag pointing to that descriptor using the
+[OCI Distribution Specification manifest push](https://github.com/opencontainers/distribution-spec/blob/v1.1.1/spec.md#pushing-manifests)
 mechanism.
 
 `AliasName` **MUST** be rejected if it is a valid OCM version string.
 
-Because `VersionOrAliasName` **MAY** itself be a non-version alias, implementations
-**MUST** accept non-semver names there and resolve them to their underlying descriptor
-before tagging. This enables alias chains: e.g., pointing `edge` to wherever `latest`
-currently resolves.
-
-After a successful push the alias tag in the registry **MUST** resolve to the descriptor
-identified by `VersionOrAliasName`. If the tag already pointed elsewhere it is overwritten.
+After a successful push the alias tag **MUST** resolve to the descriptor identified by
+`VersionOrAliasName`. If the tag already pointed elsewhere it is overwritten.
 
 **`RemoveComponentVersionAlias`**
 


### PR DESCRIPTION
#### What this PR does / why we need it
https://github.com/open-component-model/ocm-project/issues/956 introduces floating-tag support in ocm.
This PR adds the required spec changes.

For the floating tag tag add & delete support, we currently implement them in two backend
- oci 
- ctf

For this we introduced `AliasComponentVersionRepository`, which is reflected in the operations file.
Each backend covers its requirements for the implementation in the respective files.


#### Which issue(s) this PR is related to
Fixes: https://github.com/open-component-model/ocm-project/issues/1172